### PR TITLE
Add pulsing active marker and click-to-navigate markers

### DIFF
--- a/src/components/storymap/MapContainer.jsx
+++ b/src/components/storymap/MapContainer.jsx
@@ -271,23 +271,18 @@ export default function MapBackground({
         // Add new markers
         markers.forEach((markerData, index) => {
             const el = document.createElement('div');
-            el.className = 'mapbox-marker';
+            el.className = index === activeMarkerIndex ? 'mapbox-marker mapbox-marker-active' : 'mapbox-marker';
             el.style.cssText = `
-                width: 24px;
-                height: 24px;
+                width: ${index === activeMarkerIndex ? '32px' : '24px'};
+                height: ${index === activeMarkerIndex ? '32px' : '24px'};
                 border-radius: 50%;
                 background: ${index === activeMarkerIndex ? '#d97706' : '#475569'};
                 border: 3px solid white;
                 box-shadow: 0 2px 8px rgba(0,0,0,0.3);
                 cursor: pointer;
-                transition: all 0.3s ease;
+                transition: background 0.3s ease, width 0.3s ease, height 0.3s ease;
+                z-index: ${index === activeMarkerIndex ? '10' : '1'};
             `;
-
-            if (index === activeMarkerIndex) {
-                el.style.width = '32px';
-                el.style.height = '32px';
-                el.style.zIndex = '10';
-            }
 
             const marker = new mapboxgl.Marker(el)
                 .setLngLat([markerData.coordinates[1], markerData.coordinates[0]])
@@ -441,6 +436,19 @@ export default function MapBackground({
                 .mapboxgl-ctrl-group button + button {
                     border-top: none !important;
                     border-left: 1px solid rgba(226, 232, 240, 0.5) !important;
+                }
+                @keyframes marker-pulse {
+                    0%, 100% {
+                        transform: scale(1);
+                        box-shadow: 0 0 0 0 rgba(217, 119, 6, 0.4);
+                    }
+                    50% {
+                        transform: scale(1.15);
+                        box-shadow: 0 0 12px 4px rgba(217, 119, 6, 0.2);
+                    }
+                }
+                .mapbox-marker-active {
+                    animation: marker-pulse 2s ease-in-out infinite;
                 }
             `}</style>
         </div>

--- a/src/pages/StoryMapView.jsx
+++ b/src/pages/StoryMapView.jsx
@@ -48,7 +48,9 @@ export default function StoryMapView() {
     const [showBlackOverlay, setShowBlackOverlay] = useState(true);
     const [hasExplored, setHasExplored] = useState(false);
     const [isFullScreenOpen, setIsFullScreenOpen] = useState(false);
-    
+    const [storyMarkers, setStoryMarkers] = useState([]);
+    const [activeMarkerIdx, setActiveMarkerIdx] = useState(-1);
+
     const chapterRefs = useRef([]);
     const containerRef = useRef(null);
 
@@ -213,6 +215,8 @@ export default function StoryMapView() {
                             
                             previousChapterRef.current = index;
                             setActiveChapter(index);
+                            setStoryMarkers([]);
+                            setActiveMarkerIdx(-1);
                             const chapter = chapters[index];
                             
                             // Build initial route for new chapter with first slide coordinates
@@ -355,6 +359,12 @@ export default function StoryMapView() {
                 landingMarkers={landingMarkers}
                 clearLandingMarkers={clearLandingMarkers}
                 activeLayerId={activeLayerId}
+                markers={storyMarkers}
+                activeMarkerIndex={activeMarkerIdx}
+                onMarkerClick={(markerIndex) => {
+                    const marker = storyMarkers[markerIndex];
+                    if (marker) navigateToChapter(marker.chapterIndex);
+                }}
             />
             
             {/* Story Content */}
@@ -448,6 +458,26 @@ export default function StoryMapView() {
                                     mapStyle: chapter.map_style || 'light',
                                     shouldRotate: false,
                                     flyDuration: slide.fly_duration !== undefined ? slide.fly_duration : (chapter.fly_duration || 12)
+                                });
+
+                                // Build interactive marker for this slide
+                                setStoryMarkers(prev => {
+                                    const exists = prev.findIndex(m => areCoordinatesEqual(m.coordinates, normalizedCoords));
+                                    if (exists === -1) {
+                                        const newMarkers = [...prev, {
+                                            coordinates: normalizedCoords,
+                                            title: slide.title || '',
+                                            location: slide.location || '',
+                                            image: slide.image || '',
+                                            description: slide.description || '',
+                                            chapterIndex: index
+                                        }];
+                                        setActiveMarkerIdx(newMarkers.length - 1);
+                                        return newMarkers;
+                                    } else {
+                                        setActiveMarkerIdx(exists);
+                                        return prev;
+                                    }
                                 });
                             }}
                         />


### PR DESCRIPTION
Wire up the existing markers infrastructure in MapContainer to StoryMapView. Visited slide locations now show as clickable dots on the map — amber with pulse animation for the current destination, slate gray for previously visited. Clicking a marker scrolls to the corresponding chapter.