### PR TITLE
 Add Project Description section between hero and chapter one

### DIFF
--- a/src/components/editor/TabbedContentEditor.jsx
+++ b/src/components/editor/TabbedContentEditor.jsx
@@ -97,6 +97,24 @@ export default function TabbedContentEditor({
                                 }}
                             />
                         </div>
+                        <div>
+                            <Label>Story Description</Label>
+                            <p className="text-xs text-slate-500 mb-1">Shown as a full panel between the hero and chapter one. Leave blank to skip.</p>
+                            <ReactQuill
+                                value={item.story_description || ''}
+                                onChange={(content) => onUpdate({ ...item, story_description: content })}
+                                placeholder="An overview of the project, its context and significance..."
+                                className="bg-white"
+                                style={{ height: '150px', marginBottom: '50px' }}
+                                modules={{
+                                    toolbar: [
+                                        ['bold', 'italic', 'underline'],
+                                        [{ 'list': 'ordered'}, { 'list': 'bullet' }],
+                                        ['link']
+                                    ]
+                                }}
+                            />
+                        </div>
 
                         {/* Opening Map View */}
                         <div>

--- a/src/components/storymap/ProjectDescriptionSection.jsx
+++ b/src/components/storymap/ProjectDescriptionSection.jsx
@@ -1,0 +1,187 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { motion } from 'framer-motion';
+
+const splitHtmlIntoPages = (html, maxChars = 550) => {
+    if (!html) return [html];
+    const paragraphRegex = /<p[^>]*>.*?<\/p>/gi;
+    const paragraphs = html.match(paragraphRegex);
+    if (!paragraphs || paragraphs.length === 0) return [html];
+
+    const stripTags = (str) => str.replace(/<[^>]*>/g, '');
+    const pages = [];
+    let currentPageContent = '';
+    let currentTextLength = 0;
+
+    for (const paragraph of paragraphs) {
+        const textLength = stripTags(paragraph).length;
+        if (currentPageContent && (currentTextLength + textLength) > maxChars) {
+            pages.push(currentPageContent);
+            currentPageContent = paragraph;
+            currentTextLength = textLength;
+        } else {
+            currentPageContent += paragraph;
+            currentTextLength += textLength;
+        }
+    }
+    if (currentPageContent) pages.push(currentPageContent);
+    return pages.length > 0 ? pages : [html];
+};
+
+export default function ProjectDescriptionSection({ storyTitle, description, onContinue }) {
+    const [currentPage, setCurrentPage] = useState(0);
+    const [contentHeight, setContentHeight] = useState('auto');
+    const pageRefs = useRef([]);
+
+    const pages = splitHtmlIntoPages(description);
+
+    useEffect(() => {
+        setTimeout(() => {
+            if (pageRefs.current[0]) {
+                setContentHeight(pageRefs.current[0].offsetHeight);
+            }
+        }, 100);
+    }, []);
+
+    useEffect(() => {
+        if (pageRefs.current[currentPage]) {
+            setContentHeight(pageRefs.current[currentPage].offsetHeight);
+        }
+    }, [currentPage]);
+
+    const goToPage = (index) => setCurrentPage(index);
+
+    const handleNext = () => {
+        if (currentPage < pages.length - 1) {
+            setCurrentPage(currentPage + 1);
+        }
+    };
+
+    const handlePrev = () => {
+        if (currentPage > 0) {
+            setCurrentPage(currentPage - 1);
+        }
+    };
+
+    return (
+        <div
+            className="relative w-full pointer-events-none"
+            style={{ minHeight: '85vh', paddingTop: '50px' }}
+        >
+            <motion.div
+                initial={{ opacity: 0, x: 100 }}
+                whileInView={{ opacity: 1, x: 0 }}
+                transition={{ duration: 2, ease: 'easeOut' }}
+                viewport={{ once: false, amount: 0.5 }}
+                className="absolute left-1/2 w-[40%] min-w-[300px] max-w-[550px]"
+            >
+                <div className="relative bg-white/80 backdrop-blur-md rounded-2xl p-8 shadow-2xl border border-white/20 pointer-events-auto group">
+                    {/* Story title as section label */}
+                    {storyTitle && (
+                        <p className="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-4 text-right">
+                            {storyTitle}
+                        </p>
+                    )}
+
+                    {/* Section heading */}
+                    <h2 className="text-2xl font-bold text-black text-right mb-6">
+                        Project Description
+                    </h2>
+
+                    {/* Paginated content */}
+                    <motion.div
+                        className="relative overflow-hidden"
+                        animate={{ height: contentHeight }}
+                        transition={{ height: { duration: 0.6, ease: 'easeInOut' } }}
+                    >
+                        {pages.map((page, index) => (
+                            <motion.div
+                                key={index}
+                                ref={el => pageRefs.current[index] = el}
+                                initial={{ opacity: 0 }}
+                                animate={{ opacity: index === currentPage ? 1 : 0 }}
+                                transition={{ duration: 0.3 }}
+                                className={index === currentPage ? 'block' : 'hidden'}
+                            >
+                                <div
+                                    className="text-gray-900 leading-relaxed text-base space-y-4 text-right prose prose-sm max-w-none"
+                                    dangerouslySetInnerHTML={{ __html: page }}
+                                />
+                            </motion.div>
+                        ))}
+                    </motion.div>
+
+                    {/* Page indicators */}
+                    {pages.length > 1 && (
+                        <div className="flex items-center justify-center gap-2 mt-6">
+                            {pages.map((_, index) => (
+                                <button
+                                    key={index}
+                                    onClick={() => goToPage(index)}
+                                    className={`h-1 rounded-full transition-all duration-300 cursor-pointer ${
+                                        index === currentPage
+                                            ? 'w-8 bg-black'
+                                            : 'w-8 bg-black/30 hover:bg-black/50'
+                                    }`}
+                                    aria-label={`Go to page ${index + 1}`}
+                                />
+                            ))}
+                            <span className="ml-2 text-sm text-black/60">
+                                {currentPage + 1} / {pages.length}
+                            </span>
+                        </div>
+                    )}
+
+                    {/* Prev/next arrows — visible on hover */}
+                    {pages.length > 1 && (
+                        <>
+                            <button
+                                onClick={handlePrev}
+                                disabled={currentPage === 0}
+                                className="absolute left-2 bottom-6 w-10 h-10 rounded-full bg-black/10 hover:bg-black/20
+                                           disabled:opacity-30 disabled:cursor-not-allowed flex items-center justify-center
+                                           opacity-0 group-hover:opacity-100 transition-opacity duration-300"
+                                aria-label="Previous page"
+                            >
+                                <svg className="w-6 h-6 text-black" fill="none" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path d="M15 19l-7-7 7-7" />
+                                </svg>
+                            </button>
+                            <button
+                                onClick={handleNext}
+                                disabled={currentPage === pages.length - 1}
+                                className="absolute right-2 bottom-6 w-10 h-10 rounded-full bg-black/10 hover:bg-black/20
+                                           disabled:opacity-30 disabled:cursor-not-allowed flex items-center justify-center
+                                           opacity-0 group-hover:opacity-100 transition-opacity duration-300"
+                                aria-label="Next page"
+                            >
+                                <svg className="w-6 h-6 text-black" fill="none" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path d="M9 5l7 7-7 7" />
+                                </svg>
+                            </button>
+                        </>
+                    )}
+                </div>
+
+                {/* Scroll-down arrow */}
+                <div className="flex justify-center mt-10 pointer-events-auto">
+                    <motion.button
+                        onClick={onContinue}
+                        className="cursor-pointer"
+                        whileHover={{
+                            scale: 1.1,
+                            filter: 'drop-shadow(0 4px 6px rgba(0,0,0,0.3))',
+                            transition: { duration: 0.2, ease: 'easeInOut' }
+                        }}
+                    >
+                        <img
+                            src="https://qtrypzzcjebvfcihiynt.supabase.co/storage/v1/object/public/base44-prod/public/693030a5e25aa73dea8d72c2/a1c59b412_scrolldown-arrow.png"
+                            alt="Continue to story"
+                            width="74"
+                            height="50"
+                        />
+                    </motion.button>
+                </div>
+            </motion.div>
+        </div>
+    );
+}

--- a/src/pages/StoryMapView.jsx
+++ b/src/pages/StoryMapView.jsx
@@ -9,6 +9,7 @@ import StoryFooter from '@/components/storymap/StoryFooter';
 import StoryMapBanner from '@/components/storymap/StoryMapBanner';
 import ChapterProgress from '@/components/storymap/ChapterProgress';
 import FloatingStorySlideshow from '@/components/storymap/FloatingStorySlideshow';
+import ProjectDescriptionSection from '@/components/storymap/ProjectDescriptionSection';
 
 import DocumentManagerContent from '@/components/documents/DocumentManagerContent';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
@@ -54,6 +55,7 @@ export default function StoryMapView() {
 
     const chapterRefs = useRef([]);
     const containerRef = useRef(null);
+    const projectDescriptionRef = useRef(null);
 
     useEffect(() => {
         loadStory();
@@ -293,6 +295,14 @@ export default function StoryMapView() {
 
 
 
+    const scrollToProjectDescription = () => {
+        const element = projectDescriptionRef.current;
+        if (!element) return;
+        const rect = element.getBoundingClientRect();
+        const absoluteTop = rect.top + window.scrollY;
+        window.scrollTo({ top: absoluteTop, behavior: 'smooth' });
+    };
+
     const scrollToTop = () => {
         window.scrollTo({ top: 0, behavior: 'smooth' });
     };
@@ -385,26 +395,28 @@ export default function StoryMapView() {
                     heroVideoLoop={story.hero_video_loop}
                     onExplore={() => {
                         setHasExplored(true);
-                        navigateToChapter(0);
-                        
-                        // Animate from story opening view to first chapter
-                        if (chapters.length > 0 && chapters[0].slides?.length > 0) {
-                            const firstSlide = chapters[0].slides[0];
-                            let validCenter = [0, 0];
-                            if (firstSlide.coordinates && Array.isArray(firstSlide.coordinates) && firstSlide.coordinates.length === 2 &&
-                                !isNaN(firstSlide.coordinates[0]) && !isNaN(firstSlide.coordinates[1])) {
-                                validCenter = firstSlide.coordinates;
+                        if (story.story_description) {
+                            scrollToProjectDescription();
+                        } else {
+                            navigateToChapter(0);
+                            if (chapters.length > 0 && chapters[0].slides?.length > 0) {
+                                const firstSlide = chapters[0].slides[0];
+                                let validCenter = [0, 0];
+                                if (firstSlide.coordinates && Array.isArray(firstSlide.coordinates) && firstSlide.coordinates.length === 2 &&
+                                    !isNaN(firstSlide.coordinates[0]) && !isNaN(firstSlide.coordinates[1])) {
+                                    validCenter = firstSlide.coordinates;
+                                }
+                                setMapConfig({
+                                    center: validCenter,
+                                    offset: [-200, 0],
+                                    zoom: firstSlide.zoom || 12,
+                                    bearing: firstSlide.bearing || 0,
+                                    pitch: firstSlide.pitch || 0,
+                                    mapStyle: story.map_style || 'light',
+                                    shouldRotate: true,
+                                    flyDuration: firstSlide.fly_duration || 12
+                                });
                             }
-                            setMapConfig({
-                                center: validCenter,
-                                offset: [-200, 0],
-                                zoom: firstSlide.zoom || 12,
-                                bearing: firstSlide.bearing || 0,
-                                pitch: firstSlide.pitch || 0,
-                                mapStyle: story.map_style || 'light',
-                                shouldRotate: true,
-                                flyDuration: firstSlide.fly_duration || 12
-                            });
                         }
                     }}
                     onHeroLoaded={() => {
@@ -414,6 +426,21 @@ export default function StoryMapView() {
                 />
                 </div>
                 
+                {/* Project Description */}
+                {story.story_description && (
+                    <div
+                        ref={projectDescriptionRef}
+                        className="pointer-events-none"
+                        data-name="project-description-wrapper"
+                    >
+                        <ProjectDescriptionSection
+                            storyTitle={story.title}
+                            description={story.story_description}
+                            onContinue={() => navigateToChapter(0)}
+                        />
+                    </div>
+                )}
+
                 {/* Chapters */}
                 {chapters.map((chapter, index) => (
                     <div 


### PR DESCRIPTION
 Adds a new story_description field to Story Settings in the editor.
                           When populated, the hero scroll arrow leads to a full-height Project
                           Description panel (styled like TextPanelCarousel) before chapter one.
                           The panel supports paginated long-form content and has its own
                           scroll-down arrow to continue into the story.