### PR TITLE
Fix map opening location overridden by chapter 0 on mount

### DIFF
--- a/src/pages/StoryMapView.jsx
+++ b/src/pages/StoryMapView.jsx
@@ -24,7 +24,7 @@ export default function StoryMapView() {
     const [chapters, setChapters] = useState([]);
     const [relatedStories, setRelatedStories] = useState([]);
     const [isLoading, setIsLoading] = useState(true);
-    const [activeChapter, setActiveChapter] = useState(0);
+    const [activeChapter, setActiveChapter] = useState(-1);
     const [mapConfig, setMapConfig] = useState({
         center: [0, 0],
         zoom: 2,


### PR DESCRIPTION
activeChapter was initialised to 0, causing StoryChapter to fire onSlideChange immediately and override the story's assigned opening coordinates. Setting initial value to -1 means no chapter is active until the scroll handler detects one in the viewport.