### PR TITLE
Fix map jump on explore and add per-slide fly duration editor

### DIFF
--- a/src/components/editor/TabbedContentEditor.jsx
+++ b/src/components/editor/TabbedContentEditor.jsx
@@ -497,9 +497,25 @@ export default function TabbedContentEditor({
                             />
                             
                             <div className="pt-4 border-t">
+                                <Label>Fly Duration (seconds)</Label>
+                                <Input
+                                    type="number"
+                                    min="1"
+                                    max="60"
+                                    value={item.fly_duration ?? ''}
+                                    onChange={(e) => onUpdate({ ...item, fly_duration: e.target.value ? parseFloat(e.target.value) : undefined })}
+                                    placeholder="8"
+                                    style={{ fontSize: '0.9rem', lineHeight: '1.2rem' }}
+                                />
+                                <p className="text-xs text-slate-500 mt-1">
+                                    How long the map takes to fly to this location. Defaults to 8 seconds.
+                                </p>
+                            </div>
+
+                            <div className="pt-4 border-t">
                                 <Label>Mapbox Layer ID (Optional)</Label>
-                                <Input 
-                                    value={item.mapbox_layer_id || ''} 
+                                <Input
+                                    value={item.mapbox_layer_id || ''}
                                     onChange={(e) => onUpdate({ ...item, mapbox_layer_id: e.target.value })}
                                     placeholder="e.g., my-custom-layer"
                                     style={{ fontSize: '0.9rem', lineHeight: '1.2rem' }}

--- a/src/components/storymap/MapContainer.jsx
+++ b/src/components/storymap/MapContainer.jsx
@@ -16,7 +16,7 @@ export default function MapBackground({
     activeMarkerIndex = -1,
     onMarkerClick,
     shouldRotate = false,
-    flyDuration = 12,
+    flyDuration = 8,
     routeCoordinates = [],
     clearRoute = false,
     onRouteCleared,
@@ -76,11 +76,11 @@ export default function MapBackground({
 
     // Update map position
     useEffect(() => {
-        if (!map.current || !map.current.isStyleLoaded() || !mapContainer.current) return;
-        
+        if (!map.current || !mapContainer.current) return;
+
         // Validate center coordinates
-        if (!center || !Array.isArray(center) || center.length !== 2 || 
-            isNaN(center[0]) || isNaN(center[1]) || 
+        if (!center || !Array.isArray(center) || center.length !== 2 ||
+            isNaN(center[0]) || isNaN(center[1]) ||
             !isFinite(center[0]) || !isFinite(center[1])) {
             return;
         }
@@ -94,9 +94,29 @@ export default function MapBackground({
         const flyMs = (flyDuration || 12) * 1000;
 
         // Validate pitch value
-        const validPitch = (typeof pitch === 'number' && !isNaN(pitch) && isFinite(pitch) && pitch >= 0 && pitch <= 85) 
-            ? pitch 
+        const validPitch = (typeof pitch === 'number' && !isNaN(pitch) && isFinite(pitch) && pitch >= 0 && pitch <= 85)
+            ? pitch
             : 0;
+
+        // If style not loaded yet, jump to position instantly when it loads
+        // (covers stories with no hero image where user can interact before style is ready)
+        if (!map.current.isStyleLoaded()) {
+            const applyPosition = () => {
+                if (!map.current) return;
+                try {
+                    map.current.jumpTo({
+                        center: [center[1], center[0]],
+                        zoom: zoom || 12,
+                        bearing: bearing || 0,
+                        pitch: validPitch
+                    });
+                } catch (e) {}
+            };
+            map.current.once('load', applyPosition);
+            return () => {
+                if (map.current) map.current.off('load', applyPosition);
+            };
+        }
 
         // Always just fly to position without rotation
         try {

--- a/src/pages/StoryMapView.jsx
+++ b/src/pages/StoryMapView.jsx
@@ -32,7 +32,7 @@ export default function StoryMapView() {
         bearing: 0,
         pitch: 0,
         shouldRotate: false,
-        flyDuration: 12,
+        flyDuration: 8,
         offset: [-200, 0]
     });
     const [activeLayerId, setActiveLayerId] = useState(null);
@@ -235,23 +235,21 @@ export default function StoryMapView() {
 
                             setRouteCoordinates(initialRoute);
                             
-                            // Use first slide coordinates if available
-                            let validCenter = [0, 0];
-                            if (firstSlide?.coordinates && Array.isArray(firstSlide.coordinates) && firstSlide.coordinates.length === 2 &&
+                            // Only update map if first slide has valid coordinates
+                            if (firstSlide?.coordinates && Array.isArray(firstSlide.coordinates) &&
+                                firstSlide.coordinates.length === 2 &&
                                 !isNaN(firstSlide.coordinates[0]) && !isNaN(firstSlide.coordinates[1])) {
-                                validCenter = firstSlide.coordinates;
+                                setMapConfig({
+                                    center: firstSlide.coordinates,
+                                    offset: [-200, 0],
+                                    zoom: firstSlide?.zoom || 12,
+                                    bearing: firstSlide?.bearing || 0,
+                                    pitch: firstSlide?.pitch || 0,
+                                    mapStyle: story.map_style || 'light',
+                                    shouldRotate: true,
+                                    flyDuration: firstSlide?.fly_duration || 8
+                                });
                             }
-                            
-                            setMapConfig({
-                                center: validCenter,
-                                offset: [-200, 0],
-                                zoom: firstSlide?.zoom || 12,
-                                bearing: firstSlide?.bearing || 0,
-                                pitch: firstSlide?.pitch || 0,
-                                mapStyle: story.map_style || 'light',
-                                shouldRotate: true,
-                                flyDuration: firstSlide?.fly_duration || 12
-                            });
                         }
                     }
                 }
@@ -413,21 +411,20 @@ export default function StoryMapView() {
                             navigateToChapter(0);
                             if (chapters.length > 0 && chapters[0].slides?.length > 0) {
                                 const firstSlide = chapters[0].slides[0];
-                                let validCenter = [0, 0];
-                                if (firstSlide.coordinates && Array.isArray(firstSlide.coordinates) && firstSlide.coordinates.length === 2 &&
+                                if (firstSlide.coordinates && Array.isArray(firstSlide.coordinates) &&
+                                    firstSlide.coordinates.length === 2 &&
                                     !isNaN(firstSlide.coordinates[0]) && !isNaN(firstSlide.coordinates[1])) {
-                                    validCenter = firstSlide.coordinates;
+                                    setMapConfig({
+                                        center: firstSlide.coordinates,
+                                        offset: [-200, 0],
+                                        zoom: firstSlide.zoom || 12,
+                                        bearing: firstSlide.bearing || 0,
+                                        pitch: firstSlide.pitch || 0,
+                                        mapStyle: story.map_style || 'light',
+                                        shouldRotate: true,
+                                        flyDuration: firstSlide.fly_duration || 8
+                                    });
                                 }
-                                setMapConfig({
-                                    center: validCenter,
-                                    offset: [-200, 0],
-                                    zoom: firstSlide.zoom || 12,
-                                    bearing: firstSlide.bearing || 0,
-                                    pitch: firstSlide.pitch || 0,
-                                    mapStyle: story.map_style || 'light',
-                                    shouldRotate: true,
-                                    flyDuration: firstSlide.fly_duration || 12
-                                });
                             }
                         }
                     }}
@@ -501,7 +498,7 @@ export default function StoryMapView() {
                                     pitch: slide.pitch !== undefined ? slide.pitch : 0,
                                     mapStyle: chapter.map_style || 'light',
                                     shouldRotate: false,
-                                    flyDuration: slide.fly_duration !== undefined ? slide.fly_duration : (chapter.fly_duration || 12)
+                                    flyDuration: slide.fly_duration !== undefined ? slide.fly_duration : (chapter.fly_duration || 8)
                                 });
 
                                 // Build interactive marker for this slide


### PR DESCRIPTION
- Guard setMapConfig calls against [0,0] fallback coordinates to prevent jump to ocean before flyTo when slides lack coordinates
- MapContainer registers once('load') to jumpTo correct position when style isn't loaded yet (fixes no-hero-image stories)
- Add fly_duration number input to slide Location tab in editor
- Change all fly duration defaults from 12s to 8s