### PR TITLE
Fix map jump by using jumpTo for initial story position

### DIFF
--- a/src/components/storymap/MapContainer.jsx
+++ b/src/components/storymap/MapContainer.jsx
@@ -17,6 +17,7 @@ export default function MapBackground({
     onMarkerClick,
     shouldRotate = false,
     flyDuration = 8,
+    instant = false,
     routeCoordinates = [],
     clearRoute = false,
     onRouteCleared,
@@ -118,7 +119,21 @@ export default function MapBackground({
             };
         }
 
-        // Always just fly to position without rotation
+        // Instant positioning — jumpTo with no animation (used for initial story location
+        // while the black overlay is covering the map)
+        if (instant) {
+            try {
+                map.current.jumpTo({
+                    center: [center[1], center[0]],
+                    zoom: zoom || 12,
+                    bearing: bearing || 0,
+                    pitch: validPitch
+                });
+            } catch (e) {}
+            return;
+        }
+
+        // Animated flyTo for all user-triggered navigation
         try {
             map.current.flyTo({
                 center: [center[1], center[0]],
@@ -140,7 +155,7 @@ export default function MapBackground({
                 rotationRef.current = null;
             }
         };
-    }, [center, zoom, bearing, pitch, shouldRotate, flyDuration]);
+    }, [center, zoom, bearing, pitch, shouldRotate, flyDuration, instant]);
 
     // ============================================
     // ROUTE LINE RENDERING: Draw and animate route line on map

--- a/src/pages/StoryMapView.jsx
+++ b/src/pages/StoryMapView.jsx
@@ -61,7 +61,8 @@ export default function StoryMapView() {
         loadStory();
     }, [storyId]);
 
-    // Set initial map config from story opening view
+    // Set initial map config from story opening view — jump instantly (no animation)
+    // because the black overlay is covering the map at this point
     useEffect(() => {
         if (story && story.coordinates) {
             setMapConfig(prev => ({
@@ -70,7 +71,8 @@ export default function StoryMapView() {
                 zoom: story.zoom || 2,
                 mapStyle: story.map_style || 'light',
                 bearing: story.bearing || 0,
-                pitch: story.pitch || 0
+                pitch: story.pitch || 0,
+                instant: true
             }));
         }
     }, [story]);
@@ -373,6 +375,7 @@ export default function StoryMapView() {
                 mapStyle={mapConfig.mapStyle}
                 shouldRotate={mapConfig.shouldRotate}
                 flyDuration={mapConfig.flyDuration}
+                instant={mapConfig.instant}
                 routeCoordinates={routeCoordinates}
                 clearRoute={clearRoute}
                 onRouteCleared={() => setClearRoute(false)}


### PR DESCRIPTION
The story opening coordinates are now applied with jumpTo (no animation) since the black overlay covers the map at that point. This ensures the map is already at story.coordinates when the overlay lifts, so the first user-triggered flyTo starts from the correct position with no jump.