### PR TITLE
Miscellaneous design tweaks across three components

### DIFF
--- a/src/components/storymap/FullScreenImageViewer.jsx
+++ b/src/components/storymap/FullScreenImageViewer.jsx
@@ -109,13 +109,13 @@ export default function FullScreenImageViewer({
                         className="fixed inset-0 z-[9998] bg-white overflow-y-auto pointer-events-auto"
                     >
                         {/* Consolidated controls: back · close · next */}
-                        <div className="absolute bottom-[80px] left-1/2 -translate-x-1/2 z-50 w-[300px] flex items-center justify-between">
+                        <div className="absolute bottom-[80px] left-1/2 -translate-x-1/2 z-50 w-[240px] flex items-center justify-between">
                             <button
                                 onClick={handlePrevious}
                                 disabled={!hasMultipleSlides}
                                 className="bg-slate-100 hover:bg-slate-200 rounded-full p-3 transition-all disabled:opacity-30 disabled:cursor-not-allowed"
                             >
-                                <ChevronLeft className="w-8 h-8 text-slate-700" />
+                                <ChevronLeft className="w-6 h-6 text-slate-700" />
                             </button>
                             <button
                                 onClick={onClose}
@@ -128,7 +128,7 @@ export default function FullScreenImageViewer({
                                 disabled={!hasMultipleSlides}
                                 className="bg-slate-100 hover:bg-slate-200 rounded-full p-3 transition-all disabled:opacity-30 disabled:cursor-not-allowed"
                             >
-                                <ChevronRight className="w-8 h-8 text-slate-700" />
+                                <ChevronRight className="w-6 h-6 text-slate-700" />
                             </button>
                         </div>
 

--- a/src/components/storymap/MapContainer.jsx
+++ b/src/components/storymap/MapContainer.jsx
@@ -362,9 +362,9 @@ export default function MapBackground({
                         transition: opacity 1000ms ease, transform 1000ms ease;
                     `;
                     tooltipEl.innerHTML = `
-                        ${markerData.image ? `<img src="${markerData.image}" alt="${markerData.title}" style="width: 100%; aspect-ratio: 4/3; object-fit: cover; display: block;" />` : ''}
+                        ${markerData.image ? `<img src="${markerData.image}" alt="${markerData.title}" style="width: 100%; aspect-ratio: 16/9; object-fit: cover; display: block;" />` : ''}
                         <div style="padding: 8px 10px;">
-                            <div style="font-weight: 600; font-size: 13px; color: #1e293b; line-height: 1.3;">${markerData.title}</div>
+                            <div style="font-weight: 600; font-size: 15px; color: #1e293b; line-height: 1.3;">${markerData.title}</div>
                         </div>
                     `;
                     tooltipEl.addEventListener('click', () => {

--- a/src/components/storymap/TextPanelCarousel.jsx
+++ b/src/components/storymap/TextPanelCarousel.jsx
@@ -202,7 +202,7 @@ const TextPanelCarousel = ({ chapterTitle, slideTitle, description, extendedCont
             exit: "exit"
           })}
         >
-          <h2 className="text-sm font-semibold text-gray-600 uppercase tracking-wide text-right flex-1">
+          <h2 className="text-sm font-semibold text-gray-600 uppercase tracking-wide text-right flex-1 pb-[15px]">
             {chapterTitle}
           </h2>
           <button
@@ -299,7 +299,7 @@ const TextPanelCarousel = ({ chapterTitle, slideTitle, description, extendedCont
             {/* Location */}
             {location && (
               <motion.div
-                className="flex items-start justify-end gap-2 mt-6 mb-[30px]"
+                className="flex items-center justify-end gap-2 mt-6 mb-[30px]"
                 {...(!hasAnimatedIn && {
                   variants: locationVariants,
                   initial: "hidden",


### PR DESCRIPTION
- FullScreenImageViewer: controls bar 300px → 240px, nav arrows w-8 → w-6
- TextPanelCarousel: chapter title pb-[15px], location row items-center
- MapContainer: marker tooltip image 4:3 → 16:9, title font-size 13px → 15px