### PR TITLE
Fix panel height jump, thumbnail pop, and white flash on navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="manifest" href="/manifest.json" />
     <title>Base44 APP</title>
   </head>
-  <body>
+  <body style="background: #000; margin: 0;">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/components/storymap/FloatingStorySlideshow.jsx
+++ b/src/components/storymap/FloatingStorySlideshow.jsx
@@ -118,8 +118,8 @@ export default function FloatingStorySlideshow({ isOpen, onClose, currentStoryId
                             animate={{ y: 0 }}
                             exit={{ y: '100%' }}
                             transition={{ type: 'spring', damping: 30, stiffness: 300 }}
-                            className="fixed bottom-0 left-0 right-0 z-[66] bg-white/95 backdrop-blur-xl border-t border-slate-200 shadow-2xl"
-                            style={{ maxHeight: '50vh' }}
+                            className="fixed bottom-0 left-0 right-0 z-[66] bg-white/95 backdrop-blur-xl border-t border-slate-200 shadow-2xl overflow-hidden"
+                            style={{ height: '50vh' }}
                         >
                             <div className="max-w-7xl mx-auto p-6">
                                 {/* Header */}


### PR DESCRIPTION
- FloatingStorySlideshow: maxHeight → fixed height: 50vh + overflow:hidden so the panel always slides up to full size immediately; staggered content animates within the pre-sized container without height jumps
- index.html: inline style="background:#000" on <body> ensures black background before any JS/CSS bundles load, eliminating white flash