### PR TITLE
Slow panel/thumbnail animations, belt-and-suspenders white flash fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,14 +1,15 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" style="background: #000;">
   <head>
     <meta charset="UTF-8" />
+    <meta name="theme-color" content="#000000" />
     <link rel="icon" type="image/svg+xml" href="https://base44.com/logo_v2.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="manifest" href="/manifest.json" />
     <title>Base44 APP</title>
   </head>
   <body style="background: #000; margin: 0;">
-    <div id="root"></div>
+    <div id="root" style="background: #000;"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/src/components/storymap/FloatingStorySlideshow.jsx
+++ b/src/components/storymap/FloatingStorySlideshow.jsx
@@ -117,7 +117,7 @@ export default function FloatingStorySlideshow({ isOpen, onClose, currentStoryId
                             initial={{ y: '100%' }}
                             animate={{ y: 0 }}
                             exit={{ y: '100%' }}
-                            transition={{ type: 'spring', damping: 30, stiffness: 300 }}
+                            transition={{ duration: 2, ease: 'easeIn' }}
                             className="fixed bottom-0 left-0 right-0 z-[66] bg-white/95 backdrop-blur-xl border-t border-slate-200 shadow-2xl overflow-hidden"
                             style={{ height: '50vh' }}
                         >
@@ -180,9 +180,9 @@ export default function FloatingStorySlideshow({ isOpen, onClose, currentStoryId
                                 <AnimatePresence>
                                 {!isLoading && (
                                 <motion.div
-                                    initial={{ opacity: 0, y: 16 }}
+                                    initial={{ opacity: 0, y: 50 }}
                                     animate={{ opacity: 1, y: 0 }}
-                                    transition={{ duration: 0.5, ease: 'easeOut' }}
+                                    transition={{ duration: 1, ease: 'easeOut' }}
                                 >
                                 {filteredStories.length === 0 ? (
                                     <div className="text-center py-12 text-slate-500">

--- a/src/index.css
+++ b/src/index.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 /* Ensure black background before React mounts — prevents white flash on navigation */
-body {
+html, body, #root {
   background: #000;
 }
 


### PR DESCRIPTION
- Panel slide-in: spring → duration 2s easeIn
- Thumbnails: duration 1s easeOut, y offset 50px → 0
- White flash: black bg on html + body + #root in index.html (inline), theme-color meta tag, and html/#root added to index.css rule