### PR TITLE
Fix banner cut, white flash, and missing loading animation

### DIFF
--- a/src/components/storymap/FloatingStorySlideshow.jsx
+++ b/src/components/storymap/FloatingStorySlideshow.jsx
@@ -89,12 +89,19 @@ export default function FloatingStorySlideshow({ isOpen, onClose, currentStoryId
             <AnimatePresence>
                 {isTransitioning && (
                     <motion.div
-                        className="fixed inset-0 bg-black z-[9999] pointer-events-none"
+                        className="fixed inset-0 bg-black z-[10001] pointer-events-none"
                         initial={{ opacity: 0 }}
                         animate={{ opacity: 1 }}
                         transition={{ duration: 1, ease: 'easeInOut' }}
                         onAnimationComplete={() => {
-                            if (targetUrl) window.location.href = targetUrl;
+                            if (targetUrl) {
+                                // Append a raw DOM overlay that survives React unmounting,
+                                // bridging the gap between React teardown and browser navigation.
+                                const el = document.createElement('div');
+                                el.style.cssText = 'position:fixed;inset:0;background:#000;z-index:99999;pointer-events:none;';
+                                document.body.appendChild(el);
+                                window.location.href = targetUrl;
+                            }
                         }}
                     />
                 )}

--- a/src/pages/StoryMapView.jsx
+++ b/src/pages/StoryMapView.jsx
@@ -352,7 +352,7 @@ export default function StoryMapView() {
                 {showBlackOverlay && (
                     <motion.div
                         data-name="black-overlay"
-                        className="fixed inset-0 bg-black z-[50] pointer-events-none flex items-center justify-center"
+                        className="fixed inset-0 bg-black z-[10001] pointer-events-none flex items-center justify-center"
                         initial={{ opacity: 1 }}
                         exit={{ opacity: 0 }}
                         transition={{ duration: 1.5, ease: "easeOut" }}


### PR DESCRIPTION
Three root causes fixed:
1. Dissolve overlay z-[9999] → z-[10001]: now covers the banner (z-10000) so the full-screen dissolve is truly full-screen
2. Raw DOM overlay appended to body before window.location.href: bridges the gap between React unmounting the dissolve element and the browser actually navigating, preventing the old page content flashing through
3. StoryMapView black overlay z-[50] → z-[10001]: was below the story content container at z-[60], so content (white cards etc.) rendered on top of it; now the overlay and spinner are visible on the new page