### PR TITLE
Fix grey flash (double RAF) and always-visible loading spinner

### DIFF
--- a/src/components/storymap/FloatingStorySlideshow.jsx
+++ b/src/components/storymap/FloatingStorySlideshow.jsx
@@ -100,7 +100,13 @@ export default function FloatingStorySlideshow({ isOpen, onClose, currentStoryId
                                 const el = document.createElement('div');
                                 el.style.cssText = 'position:fixed;inset:0;background:#000;z-index:99999;pointer-events:none;';
                                 document.body.appendChild(el);
-                                window.location.href = targetUrl;
+                                // Double RAF ensures the browser paints the overlay
+                                // before we trigger navigation, preventing a 1-frame grey flash.
+                                requestAnimationFrame(() => {
+                                    requestAnimationFrame(() => {
+                                        window.location.href = targetUrl;
+                                    });
+                                });
                             }
                         }}
                     />

--- a/src/pages/StoryMapView.jsx
+++ b/src/pages/StoryMapView.jsx
@@ -357,11 +357,7 @@ export default function StoryMapView() {
                         exit={{ opacity: 0 }}
                         transition={{ duration: 1.5, ease: "easeOut" }}
                     >
-                        {isLoading && (
-                            <div className="flex flex-col items-center gap-4">
-                                <div className="w-10 h-10 rounded-full border-2 border-white/20 border-t-white animate-spin" />
-                            </div>
-                        )}
+                        <div className="w-10 h-10 rounded-full border-2 border-white/20 border-t-white animate-spin" />
                     </motion.div>
                 )}
             </AnimatePresence>


### PR DESCRIPTION
- Double requestAnimationFrame before window.location.href ensures the DOM overlay is actually painted by the browser before navigation fires, eliminating the 1-frame grey flash at the end of the dissolve
- Spinner in black overlay is now always rendered (not gated on isLoading) so it's visible throughout the entire overlay duration, regardless of how quickly the story data loads