### PR TITLE
Eliminate grey flash with pre-React HTML loader and black auth screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,22 @@
     <title>Base44 APP</title>
   </head>
   <body style="background: #000; margin: 0;">
+    <!-- Pre-React loader: visible from first browser paint, removed once React mounts -->
+    <style>
+      @keyframes _pl-spin { to { transform: rotate(360deg); } }
+      #page-loader {
+        position: fixed; inset: 0; background: #000;
+        z-index: 99999; pointer-events: none;
+        display: flex; align-items: center; justify-content: center;
+      }
+      #page-loader-spinner {
+        width: 40px; height: 40px; border-radius: 50%;
+        border: 2px solid rgba(255,255,255,0.2);
+        border-top-color: #fff;
+        animation: _pl-spin 0.8s linear infinite;
+      }
+    </style>
+    <div id="page-loader"><div id="page-loader-spinner"></div></div>
     <div id="root" style="background: #000;"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import PageNotFound from './lib/PageNotFound';
 import { AuthProvider, useAuth } from '@/lib/AuthContext';
 import UserNotRegisteredError from '@/components/UserNotRegisteredError';
+import { useEffect } from 'react';
 
 const { Pages, Layout, mainPage } = pagesConfig;
 const mainPageKey = mainPage ?? Object.keys(Pages)[0];
@@ -21,11 +22,19 @@ const LayoutWrapper = ({ children, currentPageName }) => Layout ?
 const AuthenticatedApp = () => {
   const { isLoadingAuth, isLoadingPublicSettings, authError, isAuthenticated, navigateToLogin } = useAuth();
 
+  // Remove the pre-React HTML loader once React has mounted and rendered.
+  // StoryMapView's own black overlay is already in the DOM by this point,
+  // so there is no uncovered frame between the two.
+  useEffect(() => {
+    const loader = document.getElementById('page-loader');
+    if (loader) loader.remove();
+  }, []);
+
   // Show loading spinner while checking app public settings or auth
   if (isLoadingPublicSettings || isLoadingAuth) {
     return (
-      <div className="fixed inset-0 flex items-center justify-center">
-        <div className="w-8 h-8 border-4 border-slate-200 border-t-slate-800 rounded-full animate-spin"></div>
+      <div className="fixed inset-0 bg-black flex items-center justify-center">
+        <div className="w-8 h-8 border-2 border-white/20 border-t-white rounded-full animate-spin"></div>
       </div>
     );
   }


### PR DESCRIPTION
index.html: add #page-loader div with pure CSS black background and spinner. Exists from the very first browser paint before any JS runs, covering the inter-page gap that caused the grey flash.

App.jsx: useEffect removes #page-loader once React has mounted (StoryMapView's own z-[10001] black overlay is already rendered by this point, so no gap). Auth loading state now has bg-black + matching white spinner instead of the previous transparent background which could expose grey beneath it.