### PR TITLE
Switch to SPA story navigation via React Router to eliminate grey flash

### DIFF
--- a/src/components/storymap/FloatingStorySlideshow.jsx
+++ b/src/components/storymap/FloatingStorySlideshow.jsx
@@ -4,6 +4,7 @@ import { X, ChevronLeft, ChevronRight } from 'lucide-react';
 import { base44 } from '@/api/base44Client';
 import { createPageUrl } from '@/utils';
 import { cn } from '@/lib/utils';
+import { useNavigate } from 'react-router-dom';
 
 const stripHtml = (html) => {
     if (!html) return '';
@@ -13,6 +14,7 @@ const stripHtml = (html) => {
 };
 
 export default function FloatingStorySlideshow({ isOpen, onClose, currentStoryId }) {
+    const navigate = useNavigate();
     const [stories, setStories] = useState([]);
     const [isLoading, setIsLoading] = useState(true);
     const [scrollPosition, setScrollPosition] = useState(0);
@@ -20,6 +22,14 @@ export default function FloatingStorySlideshow({ isOpen, onClose, currentStoryId
     const [isTransitioning, setIsTransitioning] = useState(false);
     const [targetUrl, setTargetUrl] = useState(null);
     const scrollContainerRef = React.useRef(null);
+
+    // When the panel closes (including after an in-page navigation), clear transition state
+    useEffect(() => {
+        if (!isOpen) {
+            setIsTransitioning(false);
+            setTargetUrl(null);
+        }
+    }, [isOpen]);
 
     useEffect(() => {
         if (isOpen) {
@@ -95,18 +105,10 @@ export default function FloatingStorySlideshow({ isOpen, onClose, currentStoryId
                         transition={{ duration: 1, ease: 'easeInOut' }}
                         onAnimationComplete={() => {
                             if (targetUrl) {
-                                // Append a raw DOM overlay that survives React unmounting,
-                                // bridging the gap between React teardown and browser navigation.
-                                const el = document.createElement('div');
-                                el.style.cssText = 'position:fixed;inset:0;background:#000;z-index:99999;pointer-events:none;';
-                                document.body.appendChild(el);
-                                // Double RAF ensures the browser paints the overlay
-                                // before we trigger navigation, preventing a 1-frame grey flash.
-                                requestAnimationFrame(() => {
-                                    requestAnimationFrame(() => {
-                                        window.location.href = targetUrl;
-                                    });
-                                });
+                                // SPA navigation — no page reload, no grey flash.
+                                // StoryMapView's reset effect will show its own black overlay
+                                // the moment the storyId changes in useSearchParams.
+                                navigate(targetUrl);
                             }
                         }}
                     />

--- a/src/pages/StoryMapView.jsx
+++ b/src/pages/StoryMapView.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useMemo, useLayoutEffect } from 'react';
 import { base44 } from '@/api/base44Client';
 import { motion, AnimatePresence } from 'framer-motion';
 import MapBackground from '@/components/storymap/MapContainer';
@@ -15,10 +15,11 @@ import DocumentManagerContent from '@/components/documents/DocumentManagerConten
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { Loader2 } from 'lucide-react';
 import { normalizeCoordinatePair, areCoordinatesEqual, isValidCoordinatePair } from '@/components/utils/coordinateUtils';
+import { useSearchParams } from 'react-router-dom';
 
 export default function StoryMapView() {
-    const urlParams = new URLSearchParams(window.location.search);
-    const storyId = urlParams.get('id');
+    const [searchParams] = useSearchParams();
+    const storyId = searchParams.get('id');
 
     const [story, setStory] = useState(null);
     const [chapters, setChapters] = useState([]);
@@ -59,6 +60,45 @@ export default function StoryMapView() {
     // Prevents the onSlideChange isActive-effect call from restarting a flyTo
     // that onContinue/onExplore already started for the initial chapter activation.
     const suppressNextOnSlideChangeMapConfig = useRef(false);
+    // Tracks the previous storyId so we can detect a story switch.
+    const prevStoryIdRef = useRef(null);
+    // Holds the pending setShowBlackOverlay(false) timeout so we can cancel it on story switch.
+    const overlayTimeoutRef = useRef(null);
+
+    // When storyId changes (SPA story switch via navigate()), immediately raise
+    // the black overlay and reset all per-story visual state so the old story
+    // is never visible through the overlay. useLayoutEffect fires synchronously
+    // before the browser paints, closing any gap between the overlay disappearing
+    // in FloatingStorySlideshow and it appearing here.
+    useLayoutEffect(() => {
+        if (prevStoryIdRef.current !== null && prevStoryIdRef.current !== storyId) {
+            // Cancel any pending overlay-fade from the previous story
+            if (overlayTimeoutRef.current) {
+                clearTimeout(overlayTimeoutRef.current);
+                overlayTimeoutRef.current = null;
+            }
+            setShowBlackOverlay(true);
+            setActiveChapter(-1);
+            setHasExplored(false);
+            setHeroMediaLoaded(false);
+            setIsBannerVisible(false);
+            setIsStorySlideshowOpen(false);
+            setIsFullScreenOpen(false);
+            setStoryMarkers([]);
+            setActiveMarkerIdx(-1);
+            setTargetSlide(null);
+            setActiveLayerId(null);
+            setRouteCoordinates([]);
+            setClearRoute(false);
+            setLandingMarkers([]);
+            setIsChapterMenuOpen(false);
+            previousChapterRef.current = -1;
+            suppressNextOnSlideChangeMapConfig.current = false;
+            chapterRefs.current = [];
+            window.scrollTo(0, 0);
+        }
+        prevStoryIdRef.current = storyId;
+    }, [storyId]);
 
     useEffect(() => {
         loadStory();
@@ -448,7 +488,8 @@ export default function StoryMapView() {
                     }}
                     onHeroLoaded={() => {
                         setHeroMediaLoaded(true);
-                        setTimeout(() => setShowBlackOverlay(false), 6000);
+                        if (overlayTimeoutRef.current) clearTimeout(overlayTimeoutRef.current);
+                        overlayTimeoutRef.current = setTimeout(() => setShowBlackOverlay(false), 6000);
                     }}
                 />
                 </div>


### PR DESCRIPTION
Replace window.location.href (full page reload) with navigate() from react-router-dom. StoryMapView now reads storyId via useSearchParams so it reacts to URL changes in-place. A useLayoutEffect fires synchronously on storyId change — before the browser paints — to raise the black overlay and reset all per-story state, ensuring seamless coverage with no grey flash between stories. Cancellable overlay timeout prevents a previous story's fade from interfering with a subsequent switch.