### PR TITLE
Fix hero scale animation not replaying on SPA story switch

### DIFF
--- a/src/components/storymap/StoryHeader.jsx
+++ b/src/components/storymap/StoryHeader.jsx
@@ -29,6 +29,7 @@ export default function StoryHeader({ title, subtitle, titleImage, subtitleImage
       {/* Hero Video or Image Background */}
       {heroType === 'video' && heroVideo ? (
         <motion.video
+          key={heroVideo}
           src={heroVideo}
           className="absolute inset-0 w-full h-full object-cover z-0"
           autoPlay
@@ -38,17 +39,24 @@ export default function StoryHeader({ title, subtitle, titleImage, subtitleImage
           onLoadedData={handleMediaLoad}
           initial={{ scale: 1.25, opacity: 0 }}
           animate={{ scale: 1, opacity: 1 }}
-          transition={{ duration: 5, ease: "easeOut", delay: 1 }}
+          transition={{
+            scale: { duration: 5, ease: "easeOut", delay: 1 },
+            opacity: { duration: 1.5, ease: "easeOut", delay: 1 }
+          }}
         />
       ) : heroImage ? (
         <motion.img
+          key={heroImage}
           src={heroImage}
           alt={title}
           className="absolute inset-0 w-full h-full object-cover z-0"
           onLoad={handleMediaLoad}
           initial={{ scale: 1.25, opacity: 0 }}
           animate={{ scale: 1, opacity: 1 }}
-          transition={{ duration: 5, ease: "easeOut", delay: 1 }}
+          transition={{
+            scale: { duration: 5, ease: "easeOut", delay: 1 },
+            opacity: { duration: 1.5, ease: "easeOut", delay: 1 }
+          }}
         />
       ) : null}
 


### PR DESCRIPTION
motion.img/video stays mounted during in-page navigation so Framer Motion never replays initial→animate. Adding key={heroImage/heroVideo} forces a remount on each story switch, restarting the scale animation from scratch.

Also splits the opacity and scale transitions: opacity fades in over 1.5s so the hero is fully visible when the overlay clears (~t+2.5s), while the 5s scale continues animating for a cinematic reveal effect.