### PR TITLE
Seamless white dissolve transition from story viewer to editor

### DIFF
--- a/src/components/storymap/StoryFooter.jsx
+++ b/src/components/storymap/StoryFooter.jsx
@@ -1,15 +1,17 @@
 import React, { useState, useEffect } from 'react';
-import { motion } from 'framer-motion';
+import { motion, AnimatePresence } from 'framer-motion';
 import { ArrowUp, LogIn, LogOut, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { createPageUrl } from '@/utils';
 import { base44 } from '@/api/base44Client';
 import { cn } from '@/lib/utils';
 
 export default function StoryFooter({ onRestart, onViewOtherStories, storyId, isVisible = true, onOpenLibrary, relatedStories = [], currentCategory }) {
+    const navigate = useNavigate();
     const [user, setUser] = useState(null);
     const [isLoading, setIsLoading] = useState(true);
+    const [isEditTransitioning, setIsEditTransitioning] = useState(false);
 
     useEffect(() => {
         const checkAuth = async () => {
@@ -33,7 +35,28 @@ export default function StoryFooter({ onRestart, onViewOtherStories, storyId, is
         base44.auth.logout();
     };
 
+    const handleEditStory = () => {
+        setIsEditTransitioning(true);
+    };
+
     return (
+        <>
+        {/* White dissolve overlay — sits below both fixed chrome bars (z-9999, z-10000)
+            so they appear to hold their positions while only map/content fades away */}
+        <AnimatePresence>
+            {isEditTransitioning && (
+                <motion.div
+                    className="fixed inset-0 bg-white pointer-events-all"
+                    style={{ zIndex: 9998 }}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    transition={{ duration: 0.5, ease: 'easeInOut' }}
+                    onAnimationComplete={() => {
+                        navigate(`${createPageUrl('StoryEditor')}?id=${storyId}`);
+                    }}
+                />
+            )}
+        </AnimatePresence>
         <div className="min-h-screen flex items-center justify-center relative">
             <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/30 to-transparent z-10" />
             
@@ -150,17 +173,17 @@ export default function StoryFooter({ onRestart, onViewOtherStories, storyId, is
 
                 {/* Edit Story Button */}
                 {storyId && (
-                    <Link
-                        to={`${createPageUrl('StoryEditor')}?id=${storyId}`}
+                    <button
+                        onClick={handleEditStory}
                         className="opacity-30 hover:opacity-100 transition-opacity duration-300 cursor-pointer"
                     >
-                        <img 
+                        <img
                             src="https://qtrypzzcjebvfcihiynt.supabase.co/storage/v1/object/public/base44-prod/public/693030a5e25aa73dea8d72c2/44e8e4095_EditStory.png"
                             alt="Edit Story"
                             width="50"
                             height="100"
                         />
-                    </Link>
+                    </button>
                 )}
 
                 {/* Library Button */}
@@ -202,5 +225,6 @@ export default function StoryFooter({ onRestart, onViewOtherStories, storyId, is
                 )}
             </div>
         </div>
+        </>
     );
 }

--- a/src/pages/StoryEditor.jsx
+++ b/src/pages/StoryEditor.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { motion } from 'framer-motion';
 import { base44 } from '@/api/base44Client';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -276,7 +277,12 @@ export default function StoryEditor() {
     }
 
     return (
-        <div className="min-h-screen bg-white p-0 md:p-[50px]">
+        <motion.div
+            className="min-h-screen bg-white p-0 md:p-[50px]"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.4, ease: 'easeOut' }}
+        >
             <div className="min-h-screen bg-slate-50 flex flex-col">
             {/* Header */}
             <div className="sticky top-0 z-50 bg-white border-b shadow-sm">
@@ -518,6 +524,6 @@ export default function StoryEditor() {
                 }}
             />
         </div>
-        </div>
+        </motion.div>
     );
 }


### PR DESCRIPTION
- Edit Story button in StoryFooter now triggers a white overlay (z-9998) that fades in over the map/content while both fixed chrome bars (top banner z-10000, footer bar z-9999) remain visible above it, creating the illusion that they hold their position
- navigate() fires after the 500ms fade completes (no page reload)
- StoryEditor gains a motion.div fade-in (400ms) so it appears smoothly after the overlay clears