### PR TITLE
Redesign carousel navigation to eliminate accidental fullscreen launches

### DIFF
--- a/src/components/storymap/ChapterCarousel.jsx
+++ b/src/components/storymap/ChapterCarousel.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import useEmblaCarousel from 'embla-carousel-react';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Maximize2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 const VideoEmbed = ({ url }) => {
@@ -72,79 +72,107 @@ export default function ChapterCarousel({ slides, onSlideChange, onImageClick, s
 
     if (!slides || slides.length === 0) return null;
 
-    // Single slide - no carousel controls needed
+    // Single slide — no nav controls, just the expand button
     if (slides.length === 1) {
         return (
-            <div className="relative h-[300px] overflow-hidden group cursor-pointer" onClick={() => onImageClick?.(0)}>
-                {slides[0].video_url ? (
-                    <VideoEmbed url={slides[0].video_url} />
-                ) : (
-                    <img 
-                        src={slides[0].image} 
-                        alt={slides[0].title}
-                        className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
-                    />
-                )}
-                <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent" />
+            <div>
+                <div className="relative h-[300px] overflow-hidden group">
+                    {slides[0].video_url ? (
+                        <VideoEmbed url={slides[0].video_url} />
+                    ) : (
+                        <img
+                            src={slides[0].image}
+                            alt={slides[0].title}
+                            className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
+                        />
+                    )}
+                    <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent pointer-events-none" />
+                    {/* Explicit expand button — top-right corner */}
+                    <button
+                        onClick={() => onImageClick?.(0)}
+                        className="absolute top-2 right-2 z-10 w-7 h-7 rounded-md bg-black/30 backdrop-blur-sm hover:bg-black/50 flex items-center justify-center transition-colors"
+                        aria-label="View fullscreen"
+                    >
+                        <Maximize2 className="w-3.5 h-3.5 text-white" />
+                    </button>
+                </div>
             </div>
         );
     }
 
     return (
-        <div className="relative h-[300px] overflow-hidden group">
-            <div ref={emblaRef} className="h-full">
-                <div className="flex h-full">
-                    {slides.map((slide, index) => (
-                        <div 
-                            key={index} 
-                            className="flex-[0_0_100%] min-w-0 h-full cursor-pointer relative"
-                            onClick={() => onImageClick?.(index)}
+        <div>
+            {/* Image area — no onClick, fullscreen only via expand button */}
+            <div className="relative h-[300px] overflow-hidden">
+                <div ref={emblaRef} className="h-full">
+                    <div className="flex h-full">
+                        {slides.map((slide, index) => (
+                            <div
+                                key={index}
+                                className="flex-[0_0_100%] min-w-0 h-full relative"
+                            >
+                                {slide.video_url ? (
+                                    <VideoEmbed url={slide.video_url} />
+                                ) : (
+                                    <img
+                                        src={slide.image}
+                                        alt={slide.title}
+                                        className="w-full h-full object-cover"
+                                    />
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                </div>
+
+                {/* Gradient overlay */}
+                <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent pointer-events-none" />
+
+                {/* Explicit expand button — top-right corner */}
+                <button
+                    onClick={() => onImageClick?.(selectedIndex)}
+                    className="absolute top-2 right-2 z-10 w-7 h-7 rounded-md bg-black/30 backdrop-blur-sm hover:bg-black/50 flex items-center justify-center transition-colors"
+                    aria-label="View fullscreen"
+                >
+                    <Maximize2 className="w-3.5 h-3.5 text-white" />
+                </button>
+            </div>
+
+            {/* Navigation strip — arrows bookending the dots, below the image */}
+            <div className="flex items-center justify-between px-3 py-2 bg-slate-50 border-t border-slate-100">
+                <button
+                    onClick={scrollPrev}
+                    className="w-7 h-7 rounded-full bg-white border border-slate-200 flex items-center justify-center hover:bg-slate-100 transition-colors flex-shrink-0"
+                    aria-label="Previous slide"
+                >
+                    <ChevronLeft className="w-4 h-4 text-slate-600" />
+                </button>
+
+                <div className="flex items-center gap-2">
+                    {slides.map((_, index) => (
+                        <button
+                            key={index}
+                            onClick={() => emblaApi?.scrollTo(index)}
+                            aria-label={`Go to slide ${index + 1}`}
+                            className="flex items-center justify-center w-6 h-6"
                         >
-                            {slide.video_url ? (
-                                <VideoEmbed url={slide.video_url} />
-                            ) : (
-                                <img 
-                                    src={slide.image} 
-                                    alt={slide.title}
-                                    className="w-full h-full object-cover transition-transform duration-300 hover:scale-105"
-                                />
-                            )}
-                        </div>
+                            <span className={cn(
+                                "block rounded-full transition-all duration-200",
+                                selectedIndex === index
+                                    ? "w-4 h-2 bg-amber-500"
+                                    : "w-2 h-2 bg-slate-300 hover:bg-slate-400"
+                            )} />
+                        </button>
                     ))}
                 </div>
-            </div>
-            
-            {/* Gradient overlay */}
-            <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent pointer-events-none" />
-            
-            {/* Navigation arrows */}
-            <button 
-                onClick={scrollPrev}
-                className="absolute left-2 top-1/2 -translate-y-1/2 w-8 h-8 rounded-full bg-white/80 backdrop-blur-sm flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity hover:bg-white z-10"
-            >
-                <ChevronLeft className="w-4 h-4 text-slate-700" />
-            </button>
-            <button 
-                onClick={scrollNext}
-                className="absolute right-2 top-1/2 -translate-y-1/2 w-8 h-8 rounded-full bg-white/80 backdrop-blur-sm flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity hover:bg-white z-10"
-            >
-                <ChevronRight className="w-4 h-4 text-slate-700" />
-            </button>
-            
-            {/* Dots indicator */}
-            <div className="absolute bottom-3 left-1/2 -translate-x-1/2 flex gap-1.5">
-                {slides.map((_, index) => (
-                    <button
-                        key={index}
-                        onClick={() => emblaApi?.scrollTo(index)}
-                        className={cn(
-                            "w-2 h-2 rounded-full transition-all",
-                            selectedIndex === index 
-                                ? "bg-white w-4" 
-                                : "bg-white/50 hover:bg-white/70"
-                        )}
-                    />
-                ))}
+
+                <button
+                    onClick={scrollNext}
+                    className="w-7 h-7 rounded-full bg-white border border-slate-200 flex items-center justify-center hover:bg-slate-100 transition-colors flex-shrink-0"
+                    aria-label="Next slide"
+                >
+                    <ChevronRight className="w-4 h-4 text-slate-600" />
+                </button>
             </div>
         </div>
     );


### PR DESCRIPTION
- Remove whole-image onClick — fullscreen now requires the explicit Maximize2 button in the top-right corner of the image (single and multi-slide)
- Move navigation out of the image: arrows and dots now live in a dedicated strip below the image (bg-slate-50, border-t) — no overlap with image area
- Strip layout: [←]  dots  [→] — arrows bookend the dots as a unified control
- Dot hit targets enlarged to 24×24px buttons with small visual indicators inside
- Active dot is a wider amber pill (w-4 h-2); inactive dots are slate circles