### PR TITLE
Dim inactive markers at element level; remove stray expand button

### DIFF
--- a/src/components/storymap/ChapterCarousel.jsx
+++ b/src/components/storymap/ChapterCarousel.jsx
@@ -75,7 +75,7 @@ export default function ChapterCarousel({ slides, onSlideChange, onImageClick, s
 
     if (!slides || slides.length === 0) return null;
 
-    // Single slide — no nav controls, just the expand button
+    // Single slide — no nav controls needed
     if (slides.length === 1) {
         return (
             <div>
@@ -126,15 +126,6 @@ export default function ChapterCarousel({ slides, onSlideChange, onImageClick, s
 
             {/* Gradient overlay */}
             <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent pointer-events-none" />
-
-            {/* Explicit expand button — top-right corner */}
-            <button
-                onClick={() => onImageClick?.(selectedIndex)}
-                className="absolute top-2 right-2 z-10 w-7 h-7 rounded-md bg-black/30 backdrop-blur-sm hover:bg-black/50 flex items-center justify-center transition-colors"
-                aria-label="View fullscreen"
-            >
-                <Maximize2 className="w-3.5 h-3.5 text-white" />
-            </button>
 
             {/* Navigation strip — overlaid at bottom of image with 30% opacity background */}
             <div className="absolute bottom-0 left-0 right-0 z-10 flex items-center justify-between px-3 py-2 bg-black/30 backdrop-blur-sm">

--- a/src/components/storymap/MapContainer.jsx
+++ b/src/components/storymap/MapContainer.jsx
@@ -331,13 +331,13 @@ export default function MapBackground({
                 width: ${isActive ? '36px' : '24px'};
                 height: ${isActive ? '36px' : '24px'};
                 border-radius: 50%;
-                background: ${isActive ? chapterColor.main : 'rgba(0,0,0,0.5)'};
+                background: ${chapterColor.main};
                 border: 3px solid white;
                 box-shadow: 0 2px 8px rgba(0,0,0,0.3);
                 cursor: ${isActive ? 'default' : 'pointer'};
                 pointer-events: auto;
                 opacity: 0;
-                transition: background 0.3s ease, width 0.3s ease, height 0.3s ease, opacity 500ms ease;
+                transition: opacity 300ms ease, width 0.3s ease, height 0.3s ease;
                 z-index: ${isActive ? '10' : '8'};
             `;
 
@@ -345,9 +345,9 @@ export default function MapBackground({
                 .setLngLat([markerData.coordinates[1], markerData.coordinates[0]])
                 .addTo(map.current);
 
-            // Fade in after marker is in the DOM
+            // Fade in after marker is in the DOM — inactive markers rest at 50% opacity
             requestAnimationFrame(() => {
-                requestAnimationFrame(() => { if (el) el.style.opacity = '1'; });
+                requestAnimationFrame(() => { if (el) el.style.opacity = isActive ? '1' : '0.5'; });
             });
 
             // Previous markers: tooltip on hover with thumbnail + title, click to navigate
@@ -355,6 +355,7 @@ export default function MapBackground({
                 let tooltipEl = null;
 
                 el.addEventListener('mouseenter', () => {
+                    el.style.opacity = '1';
                     if (tooltipEl) return;
                     const rect = el.getBoundingClientRect();
                     tooltipEl = document.createElement('div');
@@ -401,6 +402,7 @@ export default function MapBackground({
                 });
 
                 el.addEventListener('mouseleave', () => {
+                    el.style.opacity = '0.5';
                     setTimeout(() => {
                         if (tooltipEl && !tooltipEl.matches(':hover')) {
                             tooltipEl.remove();


### PR DESCRIPTION
- Inactive markers: opacity 0.5 (dims entire element — dot, border, shadow) brightens to 1 on hover, returns to 0.5 on mouseleave
- Active marker unchanged: full opacity, chapter colour, sonar pulse
- Revert inactive marker background to full chapter colour (opacity handles dimming)
- Remove remaining Maximize2 expand button from multi-slide carousel (was also causing a build error — Maximize2 not in imports)
- Clean up stale single-slide comment