### PR TITLE
Fix inactive marker opacity: set inline directly instead of via rAF

### DIFF
--- a/src/components/storymap/MapContainer.jsx
+++ b/src/components/storymap/MapContainer.jsx
@@ -326,9 +326,7 @@ export default function MapBackground({
             const colorIdx = (markerData.chapterIndex ?? 0) % CHAPTER_COLORS.length;
             const chapterColor = CHAPTER_COLORS[colorIdx];
             const el = document.createElement('div');
-            el.className = isActive
-                ? `mapbox-marker mapbox-marker-active-${colorIdx}`
-                : 'mapbox-marker mapbox-marker-inactive';
+            el.className = isActive ? `mapbox-marker mapbox-marker-active-${colorIdx}` : 'mapbox-marker';
             el.style.cssText = `
                 width: ${isActive ? '36px' : '24px'};
                 height: ${isActive ? '36px' : '24px'};
@@ -338,8 +336,8 @@ export default function MapBackground({
                 box-shadow: 0 2px 8px rgba(0,0,0,0.3);
                 cursor: ${isActive ? 'default' : 'pointer'};
                 pointer-events: auto;
-                ${isActive ? 'opacity: 0;' : ''}
-                transition: width 0.3s ease, height 0.3s ease;
+                opacity: ${isActive ? '0' : '0.5'};
+                transition: opacity 300ms ease, width 0.3s ease, height 0.3s ease;
                 z-index: ${isActive ? '10' : '8'};
             `;
 
@@ -359,6 +357,7 @@ export default function MapBackground({
                 let tooltipEl = null;
 
                 el.addEventListener('mouseenter', () => {
+                    el.style.opacity = '1';
                     if (tooltipEl) return;
                     const rect = el.getBoundingClientRect();
                     tooltipEl = document.createElement('div');
@@ -405,6 +404,7 @@ export default function MapBackground({
                 });
 
                 el.addEventListener('mouseleave', () => {
+                    el.style.opacity = '0.5';
                     setTimeout(() => {
                         if (tooltipEl && !tooltipEl.matches(':hover')) {
                             tooltipEl.remove();
@@ -590,8 +590,6 @@ export default function MapBackground({
                 .mapbox-marker-active-3 { animation: marker-pulse-3 1.8s ease-out infinite !important; }
                 .mapbox-marker-active-4 { animation: marker-pulse-4 1.8s ease-out infinite !important; }
                 .mapbox-marker-active-5 { animation: marker-pulse-5 1.8s ease-out infinite !important; }
-                .mapbox-marker-inactive { opacity: 0.5; transition: opacity 300ms ease; }
-                .mapbox-marker-inactive:hover { opacity: 1; }
             `}</style>
         </div>
     );


### PR DESCRIPTION
Setting opacity: 0.5 directly in cssText (instead of opacity: 0 + rAF) ensures markers render at correct opacity immediately. Restored JS mouseenter/mouseleave handlers for per-element hover effect (each el is captured individually in closure so only the hovered marker responds).