### PR TITLE
Add pre-computed road routes via Mapbox Directions API

### DIFF
--- a/src/components/editor/TabbedContentEditor.jsx
+++ b/src/components/editor/TabbedContentEditor.jsx
@@ -14,14 +14,20 @@ import DocumentPicker from '@/components/editor/DocumentPicker';
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 
-export default function TabbedContentEditor({ 
-    itemType, 
-    item, 
+export default function TabbedContentEditor({
+    itemType,
+    item,
     storyId,
     onUpdate,
     onDelete,
     onAddChapter,
-    onAddSlide 
+    onAddSlide,
+    onComputeRoutes,
+    onClearRoutes,
+    isComputingRoutes,
+    routeComputeStatus,
+    chapterRouteCount,
+    totalChapterCount
 }) {
     const [activeTab, setActiveTab] = useState('content');
     const [isUploadingImage, setIsUploadingImage] = useState(false);
@@ -300,6 +306,45 @@ export default function TabbedContentEditor({
                                 />
                                 <Label>Allow social media sharing</Label>
                             </div>
+                        </div>
+
+                        {/* Route Settings */}
+                        <div className="border-t pt-4 mt-4 space-y-3">
+                            <div className="flex items-center gap-3">
+                                <Switch
+                                    checked={item.show_route !== false}
+                                    onCheckedChange={(checked) => onUpdate({ ...item, show_route: checked })}
+                                />
+                                <Label>Show Route Line</Label>
+                            </div>
+
+                            {item.show_route !== false && (
+                                <div className="space-y-2">
+                                    <div className="flex gap-2">
+                                        <Button
+                                            size="sm"
+                                            variant="outline"
+                                            onClick={onComputeRoutes}
+                                            disabled={isComputingRoutes}
+                                        >
+                                            {isComputingRoutes ? 'Computing...' : 'Compute Routes'}
+                                        </Button>
+                                        {chapterRouteCount > 0 && (
+                                            <Button size="sm" variant="ghost" onClick={onClearRoutes}>
+                                                Clear
+                                            </Button>
+                                        )}
+                                    </div>
+                                    {routeComputeStatus && (
+                                        <p className="text-xs text-slate-500">{routeComputeStatus}</p>
+                                    )}
+                                    {chapterRouteCount > 0 && !routeComputeStatus && (
+                                        <p className="text-xs text-slate-500">
+                                            {chapterRouteCount}/{totalChapterCount} chapters have routes
+                                        </p>
+                                    )}
+                                </div>
+                            )}
                         </div>
 
                         <div className="pt-4 border-t">

--- a/src/pages/StoryEditor.jsx
+++ b/src/pages/StoryEditor.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { normalizeCoordinatePair } from '@/components/utils/coordinateUtils';
 import { motion, AnimatePresence } from 'framer-motion';
 import { base44 } from '@/api/base44Client';
 import { Button } from '@/components/ui/button';
@@ -29,6 +30,8 @@ export default function StoryEditor() {
     const [isHelpPanelOpen, setIsHelpPanelOpen] = useState(false);
     const [showTitleValidationDialog, setShowTitleValidationDialog] = useState(false);
     const [pendingTitle, setPendingTitle] = useState('');
+    const [isComputingRoutes, setIsComputingRoutes] = useState(false);
+    const [routeComputeStatus, setRouteComputeStatus] = useState(null);
 
     useEffect(() => {
         loadData();
@@ -170,6 +173,62 @@ export default function StoryEditor() {
 
     const updateSlide = (updatedSlide) => {
         setSlides(slides.map(s => s.id === updatedSlide.id ? updatedSlide : s));
+    };
+
+    const computeRoutes = async () => {
+        const token = import.meta.env.VITE_MAPBOX_API_KEY || 'pk.eyJ1Ijoic3RldmVidXR0b24iLCJhIjoiNEw1T183USJ9.Sv_1qSC23JdXot8YIRPi8A';
+        setIsComputingRoutes(true);
+        setRouteComputeStatus(null);
+        let successCount = 0;
+
+        for (const chapter of chapters) {
+            const chapterSlides = slides
+                .filter(s => s.chapter_id === chapter.id)
+                .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+
+            const validCoords = chapterSlides
+                .map(s => normalizeCoordinatePair(s.coordinates))
+                .filter(Boolean);
+
+            if (validCoords.length < 2) continue;
+
+            // Mapbox Directions max 25 waypoints — cap if needed
+            const capped = validCoords.length > 25
+                ? [validCoords[0], ...validCoords.slice(1, 24), validCoords[validCoords.length - 1]]
+                : validCoords;
+
+            const waypoints = capped.map(c => `${c[1]},${c[0]}`).join(';');
+
+            try {
+                const resp = await fetch(
+                    `https://api.mapbox.com/directions/v5/mapbox/driving/${waypoints}` +
+                    `?geometries=geojson&overview=full&access_token=${token}`
+                );
+                const data = await resp.json();
+                if (data.routes?.[0]?.geometry?.coordinates) {
+                    // Convert Directions API [lng,lat] → internal [lat,lng]
+                    const routeGeometry = data.routes[0].geometry.coordinates.map(c => [c[1], c[0]]);
+                    await base44.entities.Chapter.update(chapter.id, { route_geometry: routeGeometry });
+                    setChapters(prev => prev.map(ch =>
+                        ch.id === chapter.id ? { ...ch, route_geometry: routeGeometry } : ch
+                    ));
+                    successCount++;
+                }
+            } catch (e) {
+                // Skip failed chapter (sea crossing, remote area, etc.) — continue
+            }
+        }
+
+        setIsComputingRoutes(false);
+        setRouteComputeStatus(`${successCount} of ${chapters.length} chapter routes computed`);
+    };
+
+    const clearRoutes = async () => {
+        for (const chapter of chapters) {
+            await base44.entities.Chapter.update(chapter.id, { route_geometry: null });
+        }
+        setChapters(prev => prev.map(ch => ({ ...ch, route_geometry: null })));
+        setRouteComputeStatus('Routes cleared');
     };
 
     const deleteChapter = async (chapterId) => {
@@ -434,6 +493,12 @@ export default function StoryEditor() {
                             }
                             onAddChapter={addChapter}
                             onAddSlide={addSlide}
+                            onComputeRoutes={computeRoutes}
+                            onClearRoutes={clearRoutes}
+                            isComputingRoutes={isComputingRoutes}
+                            routeComputeStatus={routeComputeStatus}
+                            chapterRouteCount={chapters.filter(c => c.route_geometry?.length).length}
+                            totalChapterCount={chapters.length}
                         />
                     </div>
                 </div>

--- a/src/pages/StoryMapView.jsx
+++ b/src/pages/StoryMapView.jsx
@@ -270,18 +270,22 @@ export default function StoryMapView() {
                             setActiveMarkerIdx(-1);
                             const chapter = chapters[index];
 
-                            // Build initial route for new chapter with first slide coordinates
-                            const initialRoute = [];
                             const firstSlide = chapter.slides?.[0];
 
-                            if (firstSlide?.coordinates) {
-                                const normalized = normalizeCoordinatePair(firstSlide.coordinates);
-                                if (normalized) {
-                                    initialRoute.push(normalized);
+                            if (story.show_route === false) {
+                                // Route disabled for this story — leave routeCoordinates empty
+                            } else if (chapter.route_geometry?.length >= 2) {
+                                // Use full pre-computed road route
+                                setRouteCoordinates(chapter.route_geometry);
+                            } else {
+                                // Fallback: seed with first slide coordinate (straight-line behaviour)
+                                const initialRoute = [];
+                                if (firstSlide?.coordinates) {
+                                    const normalized = normalizeCoordinatePair(firstSlide.coordinates);
+                                    if (normalized) initialRoute.push(normalized);
                                 }
+                                setRouteCoordinates(initialRoute);
                             }
-
-                            setRouteCoordinates(initialRoute);
 
                             // Only update map for chapter-to-chapter transitions.
                             // The initial hero/description→chapter0 activation is already
@@ -553,14 +557,16 @@ export default function StoryMapView() {
 
                                 const normalizedCoords = normalizeCoordinatePair(slide.coordinates);
 
-                                // Add to route (with duplicate check)
-                                setRouteCoordinates(prev => {
-                                    const lastCoord = prev[prev.length - 1];
-                                    if (!lastCoord || !areCoordinatesEqual(lastCoord, normalizedCoords)) {
-                                        return [...prev, normalizedCoords];
-                                    }
-                                    return prev;
-                                });
+                                // Don't accumulate individual coords when a full route is already loaded
+                                if (story.show_route !== false && !(chapters[index]?.route_geometry?.length >= 2)) {
+                                    setRouteCoordinates(prev => {
+                                        const lastCoord = prev[prev.length - 1];
+                                        if (!lastCoord || !areCoordinatesEqual(lastCoord, normalizedCoords)) {
+                                            return [...prev, normalizedCoords];
+                                        }
+                                        return prev;
+                                    });
+                                }
 
                                 // Add landing marker (with duplicate check)
                                 setLandingMarkers(prev => {


### PR DESCRIPTION
- StoryEditor: computeRoutes() calls Mapbox Directions sequentially per chapter, stores road geometry on Chapter.route_geometry ([lat,lng][]); clearRoutes() nulls geometry on all chapters; isComputingRoutes / routeComputeStatus state drives UI feedback
- TabbedContentEditor: Route Settings section with Show Route Line toggle, Compute Routes / Clear buttons, status message, and chapter count badge
- StoryMapView: handleScroll respects show_route flag and uses pre-computed route_geometry when present; onSlideChange skips coordinate accumulation when a full road route is already loaded for the chapter