### PR TITLE
Add Live Map Editor: floating panel for real-time slide map adjustments

### DIFF
--- a/docs/live-map-editor.md
+++ b/docs/live-map-editor.md
@@ -1,0 +1,175 @@
+# Live Map Editor — Design & Implementation Notes
+
+## Problem
+
+Adjusting map settings (zoom, bearing, pitch, fly duration) currently requires:
+1. Open Story Editor
+2. Navigate to the slide
+3. Guess at values while imagining the map relationship
+4. Save → go to viewer → scroll to that slide → observe result
+5. Repeat until correct
+
+This is slow and disconnected. The map and the slide are never seen together during editing.
+
+---
+
+## Solution
+
+A floating live-edit panel activated **while viewing the story**. The author sees the
+story exactly as a reader would, but with access to a control panel that updates the map
+in real time and saves changes directly to the database.
+
+---
+
+## Activation
+
+- A subtle **edit icon in the story footer** (not the banner, not the chapter nav)
+- Chosen location: footer keeps it out of the reading experience and away from chapter
+  navigation, but accessible when the author reaches the end of a section or scrolls back
+- Icon only — no label — so it doesn't distract readers
+
+---
+
+## Ownership & Auth (Future-Proofing)
+
+Currently: single user, no gating needed.
+
+Future: the icon should only render if `story.created_by === currentUser.id` (or equivalent
+ownership check once Supabase migration is complete). The component should accept an
+`isOwner` prop that controls visibility. For now, `isOwner` defaults to `true`.
+
+Implementation note: after Supabase migration, pass `isOwner` from `StoryMapView` by
+comparing the authenticated user ID to `story.user_id` (or equivalent ownership field).
+
+---
+
+## The Panel
+
+### Behaviour
+- Activating the icon opens a floating panel anchored to the **left side of the map**
+  (right half of the screen), above the footer
+- Panel tracks the **currently active slide** — updates its displayed values as the user
+  scrolls to new slides/chapters
+- All slider changes update the map **live** (no save needed to preview)
+- A "Save" button writes the current values back to the Slide entity in the database
+
+### Controls (per slide)
+
+| Control | Type | Range |
+|---|---|---|
+| Zoom | Slider | 1–20 |
+| Bearing | Slider | -180–180° |
+| Pitch | Slider | 0–85° |
+| Fly Duration | Slider | 1–20s |
+
+### Capture Current Map Position (key feature)
+
+The most intuitive workflow:
+1. Author pans, zooms, rotates the Mapbox map freely with mouse/touch
+2. Clicks **"Capture Map Position"**
+3. Panel reads `map.getCenter()`, `map.getZoom()`, `map.getBearing()`, `map.getPitch()`
+   directly from the live Mapbox instance
+4. Values populate the sliders instantly
+5. Author clicks Save → written to database
+
+This eliminates guesswork entirely. The author positions the map exactly as they want it
+for that slide, then locks it in.
+
+### Coordinate capture
+
+A secondary **"Set Slide Coordinates"** button captures `map.getCenter()` as the slide's
+`coordinates` field — useful when the author has panned to the correct location and wants
+to anchor the slide flyTo target there.
+
+---
+
+## Data Flow
+
+```
+Author pans map
+    ↓
+"Capture Map Position" clicked
+    ↓
+Read from Mapbox: center, zoom, bearing, pitch
+    ↓
+Populate panel sliders (live preview already matches)
+    ↓
+"Save" clicked
+    ↓
+base44.entities.Slide.update(slideId, { zoom, bearing, pitch, fly_duration, coordinates })
+    ↓
+StoryMapView re-reads updated slide on next load
+```
+
+Slider changes (without capture) also trigger a live `setMapConfig` call so the author
+sees the result immediately — same mechanism the viewer already uses.
+
+---
+
+## Technical Implementation
+
+### Files to modify
+
+| File | Change |
+|---|---|
+| `src/pages/StoryMapView.jsx` | Add edit mode state, pass `mapRef` and active slide ID down; render `LiveMapEditor` |
+| `src/components/storymap/MapContainer.jsx` | Expose `mapRef` via `forwardRef` or callback prop so `LiveMapEditor` can read map state |
+| `src/components/storymap/StoryFooter.jsx` | Add edit icon button (gated by `isOwner`) |
+| `src/components/storymap/LiveMapEditor.jsx` | New component — the floating panel |
+
+### MapContainer ref exposure
+
+`MapContainer` already holds `map.current` internally. To expose it for capture:
+- Add a `onMapReady` callback prop: `onMapReady(mapInstance)` called once after map loads
+- `StoryMapView` stores it in its own `mapInstanceRef`
+- `LiveMapEditor` receives `mapInstanceRef` as a prop and calls `.getCenter()` etc. on demand
+
+### Active slide tracking
+
+`StoryMapView` already tracks the active chapter and receives slide data via `onSlideChange`.
+The `LiveMapEditor` needs:
+- `activeSlide` — the current slide object (id, zoom, bearing, pitch, fly_duration, coordinates)
+- `onSlideUpdate(updatedValues)` — callback to trigger `setMapConfig` for live preview
+- `onSlideSave(slideId, values)` — callback to write to database
+
+### Slide ID availability
+
+Currently `StoryMapView`'s `onSlideChange` receives slide data but not the slide `id`
+(it was stripped when building `chaptersWithSlides` in `loadStory`). The slide `id` needs
+to be preserved in the chapter slides array so `LiveMapEditor` can save to the correct record.
+
+---
+
+## UI Sketch
+
+```
+┌─────────────────────────────────────────────┐
+│  ✏️  Map Settings — Slide 2: "Market Square" │
+│─────────────────────────────────────────────│
+│  Zoom          [━━━━●──────────] 14          │
+│  Bearing       [────●──────────] 45°         │
+│  Pitch         [──────●────────] 30°         │
+│  Fly Duration  [━━●────────────] 6s          │
+│                                             │
+│  [ Capture Map Position ]                   │
+│  [ Set Slide Coordinates ]                  │
+│                                             │
+│  Coordinates: 51.5074, -0.1278              │
+│                                             │
+│              [ Cancel ]  [ Save ]           │
+└─────────────────────────────────────────────┘
+```
+
+Panel is positioned fixed, bottom-right of map area, above the footer.
+Draggable is not required — fixed position is sufficient.
+
+---
+
+## Future Enhancements
+
+- **Chapter-level settings**: map style, default zoom — separate section or tab
+- **Ownership gating**: `isOwner={story.user_id === currentUser.id}` after Supabase migration
+- **Undo**: store previous values on panel open, offer revert
+- **Bulk apply**: "Apply zoom to all slides in this chapter"
+- **Route type selector**: driving / walking / cycling — natural fit here once Supabase
+  stores `route_geometry`

--- a/src/components/storymap/LiveMapEditor.jsx
+++ b/src/components/storymap/LiveMapEditor.jsx
@@ -1,0 +1,171 @@
+import React, { useState, useEffect } from 'react';
+import { base44 } from '@/api/base44Client';
+import { motion, AnimatePresence } from 'framer-motion';
+import { X, Crosshair, MapPin, Save } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Slider } from '@/components/ui/slider';
+import { toast } from 'sonner';
+
+export default function LiveMapEditor({ isOpen, onClose, activeSlide, mapInstanceRef, onSlideUpdate, onSlideSave }) {
+    const [zoom, setZoom] = useState(12);
+    const [bearing, setBearing] = useState(0);
+    const [pitch, setPitch] = useState(0);
+    const [flyDuration, setFlyDuration] = useState(8);
+    const [coordinates, setCoordinates] = useState(null);
+    const [isSaving, setIsSaving] = useState(false);
+
+    // Sync panel values from active slide when it changes
+    useEffect(() => {
+        if (!activeSlide) return;
+        setZoom(activeSlide.zoom ?? 12);
+        setBearing(activeSlide.bearing ?? 0);
+        setPitch(activeSlide.pitch ?? 0);
+        setFlyDuration(activeSlide.fly_duration ?? 8);
+        setCoordinates(activeSlide.coordinates ?? null);
+    }, [activeSlide?.id]);
+
+    const handleSliderChange = (field, value) => {
+        const updates = { zoom, bearing, pitch, fly_duration: flyDuration };
+        if (field === 'zoom')        { setZoom(value);        updates.zoom = value; }
+        if (field === 'bearing')     { setBearing(value);     updates.bearing = value; }
+        if (field === 'pitch')       { setPitch(value);       updates.pitch = value; }
+        if (field === 'flyDuration') { setFlyDuration(value); updates.fly_duration = value; }
+        if (onSlideUpdate) onSlideUpdate(updates);
+    };
+
+    const captureMapPosition = () => {
+        const map = mapInstanceRef?.current;
+        if (!map) { toast.error('Map not ready'); return; }
+        const center = map.getCenter();
+        setZoom(Math.round(map.getZoom() * 10) / 10);
+        setBearing(Math.round(map.getBearing()));
+        setPitch(Math.round(map.getPitch()));
+        setCoordinates([center.lat, center.lng]);
+        toast.success('Map position captured');
+    };
+
+    const setSlideCoordinates = () => {
+        const map = mapInstanceRef?.current;
+        if (!map) { toast.error('Map not ready'); return; }
+        const center = map.getCenter();
+        setCoordinates([center.lat, center.lng]);
+        toast.success('Coordinates set');
+    };
+
+    const handleSave = async () => {
+        if (!activeSlide?.id) { toast.error('No slide selected'); return; }
+        setIsSaving(true);
+        try {
+            const updateData = { zoom, bearing, pitch, fly_duration: flyDuration };
+            if (coordinates) updateData.coordinates = coordinates;
+            await base44.entities.Slide.update(activeSlide.id, updateData);
+            if (onSlideSave) onSlideSave(activeSlide.id, updateData);
+            toast.success('Slide saved');
+        } catch {
+            toast.error('Failed to save slide');
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    const slideLabel = activeSlide?.title ? `"${activeSlide.title}"` : 'Current Slide';
+
+    return (
+        <AnimatePresence>
+            {isOpen && (
+                <motion.div
+                    initial={{ opacity: 0, x: 20 }}
+                    animate={{ opacity: 1, x: 0 }}
+                    exit={{ opacity: 0, x: 20 }}
+                    transition={{ type: 'spring', damping: 20, stiffness: 200 }}
+                    className="fixed bottom-[76px] right-6 z-[9990] w-[300px] bg-white/97 backdrop-blur-xl rounded-xl shadow-2xl border border-slate-200/60"
+                >
+                    {/* Header */}
+                    <div className="flex items-center justify-between px-4 py-3 border-b border-slate-100">
+                        <div className="min-w-0">
+                            <div className="text-[10px] font-semibold text-slate-400 uppercase tracking-widest">Map Editor</div>
+                            <div className="text-sm font-medium text-slate-800 truncate">{slideLabel}</div>
+                        </div>
+                        <button
+                            onClick={onClose}
+                            className="ml-2 shrink-0 text-slate-400 hover:text-slate-700 transition-colors"
+                        >
+                            <X className="w-4 h-4" />
+                        </button>
+                    </div>
+
+                    {/* Sliders */}
+                    <div className="px-4 py-3 space-y-3">
+                        <SliderRow label="Zoom" value={zoom} min={1} max={20} step={0.5}
+                            display={zoom.toFixed(1)}
+                            onChange={v => handleSliderChange('zoom', v)} />
+                        <SliderRow label="Bearing" value={bearing} min={-180} max={180} step={1}
+                            display={`${bearing}°`}
+                            onChange={v => handleSliderChange('bearing', v)} />
+                        <SliderRow label="Pitch" value={pitch} min={0} max={85} step={1}
+                            display={`${pitch}°`}
+                            onChange={v => handleSliderChange('pitch', v)} />
+                        <SliderRow label="Fly (s)" value={flyDuration} min={1} max={20} step={0.5}
+                            display={`${flyDuration}s`}
+                            onChange={v => handleSliderChange('flyDuration', v)} />
+                    </div>
+
+                    {/* Action buttons */}
+                    <div className="px-4 pb-3 space-y-2">
+                        <button
+                            onClick={captureMapPosition}
+                            className="w-full py-2 px-3 rounded-lg bg-slate-100 hover:bg-slate-200 text-sm font-medium text-slate-700 flex items-center justify-center gap-2 transition-colors"
+                        >
+                            <Crosshair className="w-4 h-4" />
+                            Capture Map Position
+                        </button>
+                        <button
+                            onClick={setSlideCoordinates}
+                            className="w-full py-2 px-3 rounded-lg bg-slate-100 hover:bg-slate-200 text-sm font-medium text-slate-700 flex items-center justify-center gap-2 transition-colors"
+                        >
+                            <MapPin className="w-4 h-4" />
+                            Set Slide Coordinates
+                        </button>
+                        {coordinates && (
+                            <p className="text-[11px] text-slate-400 text-center font-mono">
+                                {coordinates[0].toFixed(4)}, {coordinates[1].toFixed(4)}
+                            </p>
+                        )}
+                    </div>
+
+                    {/* Footer */}
+                    <div className="px-4 pb-4 flex gap-2 justify-end border-t border-slate-100 pt-3">
+                        <Button size="sm" variant="ghost" onClick={onClose}>
+                            Cancel
+                        </Button>
+                        <Button
+                            size="sm"
+                            onClick={handleSave}
+                            disabled={isSaving || !activeSlide?.id}
+                            className="bg-slate-800 hover:bg-slate-700 text-white"
+                        >
+                            {isSaving ? 'Saving…' : <><Save className="w-3 h-3 mr-1" />Save</>}
+                        </Button>
+                    </div>
+                </motion.div>
+            )}
+        </AnimatePresence>
+    );
+}
+
+function SliderRow({ label, value, min, max, step, display, onChange }) {
+    return (
+        <div className="flex items-center gap-3">
+            <span className="text-xs text-slate-500 w-[52px] shrink-0">{label}</span>
+            <Slider
+                min={min}
+                max={max}
+                step={step}
+                value={[value]}
+                onValueChange={([v]) => onChange(v)}
+                className="flex-1"
+            />
+            <span className="text-xs font-mono text-slate-700 w-[40px] text-right shrink-0">{display}</span>
+        </div>
+    );
+}

--- a/src/components/storymap/MapContainer.jsx
+++ b/src/components/storymap/MapContainer.jsx
@@ -35,7 +35,8 @@ export default function MapBackground({
     landingMarkers = [],
     clearLandingMarkers = false,
     activeLayerId = null,
-    activeChapter = 0
+    activeChapter = 0,
+    onMapReady = null
 }) {
     const mapContainer = useRef(null);
     const map = useRef(null);
@@ -79,6 +80,13 @@ export default function MapBackground({
         map.current.addControl(new mapboxgl.NavigationControl({
             visualizePitch: true
         }), 'bottom-left');
+
+        // Expose the map instance to parent via onMapReady callback
+        if (onMapReady) {
+            map.current.once('load', () => {
+                if (onMapReady) onMapReady(map.current);
+            });
+        }
 
         return () => {
             if (map.current) {

--- a/src/components/storymap/StoryFooter.jsx
+++ b/src/components/storymap/StoryFooter.jsx
@@ -1,13 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { ArrowUp, LogIn, LogOut, User } from 'lucide-react';
+import { ArrowUp, LogIn, LogOut, User, SlidersHorizontal } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Link, useNavigate } from 'react-router-dom';
 import { createPageUrl } from '@/utils';
 import { base44 } from '@/api/base44Client';
 import { cn } from '@/lib/utils';
 
-export default function StoryFooter({ onRestart, onViewOtherStories, storyId, isVisible = true, onOpenLibrary, relatedStories = [], currentCategory }) {
+export default function StoryFooter({ onRestart, onViewOtherStories, storyId, isVisible = true, onOpenLibrary, relatedStories = [], currentCategory, onOpenMapEditor, isOwner = true }) {
     const navigate = useNavigate();
     const [user, setUser] = useState(null);
     const [isLoading, setIsLoading] = useState(true);
@@ -183,6 +183,17 @@ export default function StoryFooter({ onRestart, onViewOtherStories, storyId, is
                             width="50"
                             height="100"
                         />
+                    </button>
+                )}
+
+                {/* Map Editor Button */}
+                {storyId && isOwner && onOpenMapEditor && (
+                    <button
+                        onClick={onOpenMapEditor}
+                        title="Live Map Editor"
+                        className="opacity-30 hover:opacity-100 transition-opacity duration-300 cursor-pointer p-1"
+                    >
+                        <SlidersHorizontal className="w-5 h-5 text-slate-700" />
                     </button>
                 )}
 

--- a/src/pages/StoryMapView.jsx
+++ b/src/pages/StoryMapView.jsx
@@ -10,6 +10,7 @@ import StoryMapBanner from '@/components/storymap/StoryMapBanner';
 import ChapterProgress from '@/components/storymap/ChapterProgress';
 import FloatingStorySlideshow from '@/components/storymap/FloatingStorySlideshow';
 import ProjectDescriptionSection from '@/components/storymap/ProjectDescriptionSection';
+import LiveMapEditor from '@/components/storymap/LiveMapEditor';
 
 import DocumentManagerContent from '@/components/documents/DocumentManagerContent';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
@@ -85,6 +86,10 @@ export default function StoryMapView() {
     const [storyMarkers, setStoryMarkers] = useState([]);
     const [activeMarkerIdx, setActiveMarkerIdx] = useState(-1);
     const [targetSlide, setTargetSlide] = useState(null);
+
+    const [activeSlide, setActiveSlide] = useState(null);
+    const [isLiveEditorOpen, setIsLiveEditorOpen] = useState(false);
+    const mapInstanceRef = useRef(null);
 
     const chapterRefs = useRef([]);
     const containerRef = useRef(null);
@@ -255,6 +260,7 @@ export default function StoryMapView() {
                     .filter(s => s.chapter_id === chapter.id)
                     .sort((a, b) => a.order - b.order)
                     .map(s => ({
+                        id: s.id,
                         image: s.image,
                         title: s.title,
                         description: s.description,
@@ -488,6 +494,7 @@ export default function StoryMapView() {
                         setTargetSlide({ chapter: marker.chapterIndex, slide: marker.slideIndex });
                     }
                 }}
+                onMapReady={(mapInstance) => { mapInstanceRef.current = mapInstance; }}
             />
             
             {/* Story Content */}
@@ -592,6 +599,7 @@ export default function StoryMapView() {
                             onFullScreenChange={setIsFullScreenOpen}
                             targetSlideIndex={targetSlide?.chapter === index ? targetSlide.slide : undefined}
                             onSlideChange={(slide) => {
+                                setActiveSlide(slide);
                                 if (!isValidCoordinatePair(slide.coordinates)) return;
 
                                 const normalizedCoords = normalizeCoordinatePair(slide.coordinates);
@@ -712,7 +720,7 @@ export default function StoryMapView() {
                 
                 {/* Footer */}
                 <div className="pointer-events-auto" data-name="footer-wrapper">
-                <StoryFooter 
+                <StoryFooter
                     onRestart={scrollToTop}
                     onViewOtherStories={() => setIsStorySlideshowOpen(true)}
                     storyId={storyId}
@@ -720,6 +728,8 @@ export default function StoryMapView() {
                     onOpenLibrary={() => setShowLibraryModal(true)}
                     relatedStories={relatedStories}
                     currentCategory={story?.category}
+                    onOpenMapEditor={() => setIsLiveEditorOpen(true)}
+                    isOwner={true}
                 />
                 </div>
             </div>
@@ -757,6 +767,31 @@ export default function StoryMapView() {
                 currentStoryId={storyId}
             />
             </div>
+
+            {/* Live Map Editor */}
+            <LiveMapEditor
+                isOpen={isLiveEditorOpen}
+                onClose={() => setIsLiveEditorOpen(false)}
+                activeSlide={activeSlide}
+                mapInstanceRef={mapInstanceRef}
+                onSlideUpdate={(values) => {
+                    setMapConfig(prev => ({
+                        ...prev,
+                        zoom: values.zoom ?? prev.zoom,
+                        bearing: values.bearing ?? prev.bearing,
+                        pitch: values.pitch ?? prev.pitch,
+                        instant: true
+                    }));
+                }}
+                onSlideSave={(slideId, values) => {
+                    setChapters(prev => prev.map(chapter => ({
+                        ...chapter,
+                        slides: chapter.slides?.map(slide =>
+                            slide.id === slideId ? { ...slide, ...values } : slide
+                        )
+                    })));
+                }}
+            />
 
             {/* Document Library Sheet */}
             <Sheet 


### PR DESCRIPTION
- New LiveMapEditor component: sliders for zoom/bearing/pitch/fly duration, Capture Map Position (reads live Mapbox state), Set Slide Coordinates, and Save (writes directly to Slide entity in the database)
- MapContainer: expose map instance via onMapReady callback after load
- StoryMapView: track activeSlide (now includes slide id), wire mapInstanceRef, add onSlideUpdate for instant live preview and onSlideSave to sync local state; add id field to slide mapping in loadStory (was missing, blocked DB saves)
- StoryFooter: SlidersHorizontal icon button in footer bar activates the panel, gated by isOwner prop (defaults true, ready for ownership check post-migration)
- Design notes saved to docs/live-map-editor.md