### PR TITLE
TEST: disable [-200,0] camera offset to diagnose vertical discrepancy

### DIFF
--- a/src/components/storymap/LiveMapEditor.jsx
+++ b/src/components/storymap/LiveMapEditor.jsx
@@ -9,7 +9,7 @@ import { toast } from 'sonner';
 
 // The horizontal offset the story viewer applies so the slide location sits
 // to the right of the chapter text panel. Must match StoryMapView's flyTo offset.
-const STORY_OFFSET = [-200, 0];
+const STORY_OFFSET = [0, 0];  // TEST: offset disabled — was [-200, 0]
 
 export default function LiveMapEditor({ isOpen, onClose, activeSlide, mapInstanceRef, onSlideSave }) {
     const [zoom, setZoom] = useState(12);

--- a/src/pages/StoryMapView.jsx
+++ b/src/pages/StoryMapView.jsx
@@ -67,7 +67,7 @@ export default function StoryMapView() {
         pitch: 0,
         shouldRotate: false,
         flyDuration: 8,
-        offset: [-200, 0]
+        offset: [0, 0]  // TEST: offset disabled — was [-200, 0]
     });
     const [activeLayerId, setActiveLayerId] = useState(null);
     const [routeCoordinates, setRouteCoordinates] = useState([]);
@@ -342,7 +342,7 @@ export default function StoryMapView() {
                                 !isNaN(firstSlide.coordinates[0]) && !isNaN(firstSlide.coordinates[1])) {
                                 setMapConfig({
                                     center: firstSlide.coordinates,
-                                    offset: [-200, 0],
+                                    offset: [0, 0],  // TEST: offset disabled — was [-200, 0]
                                     zoom: firstSlide?.zoom || 12,
                                     bearing: firstSlide?.bearing || 0,
                                     pitch: firstSlide?.pitch || 0,
@@ -525,7 +525,7 @@ export default function StoryMapView() {
                                     suppressNextOnSlideChangeMapConfig.current = true;
                                     setMapConfig({
                                         center: firstSlide.coordinates,
-                                        offset: [-200, 0],
+                                        offset: [0, 0],  // TEST: offset disabled — was [-200, 0]
                                         zoom: firstSlide.zoom || 12,
                                         bearing: firstSlide.bearing || 0,
                                         pitch: firstSlide.pitch || 0,
@@ -567,7 +567,7 @@ export default function StoryMapView() {
                                         suppressNextOnSlideChangeMapConfig.current = true;
                                         setMapConfig({
                                             center: firstSlide.coordinates,
-                                            offset: [-200, 0],
+                                            offset: [0, 0],  // TEST: offset disabled — was [-200, 0]
                                             zoom: firstSlide.zoom || 12,
                                             bearing: firstSlide.bearing || 0,
                                             pitch: firstSlide.pitch || 0,
@@ -676,7 +676,7 @@ export default function StoryMapView() {
                                 } else {
                                     setMapConfig({
                                         center: slide.coordinates,
-                                        offset: [-200, 0],
+                                        offset: [0, 0],  // TEST: offset disabled — was [-200, 0]
                                         zoom: slide.zoom !== undefined ? slide.zoom : (chapter.zoom || 12),
                                         bearing: slide.bearing !== undefined ? slide.bearing : 0,
                                         pitch: slide.pitch !== undefined ? slide.pitch : 0,


### PR DESCRIPTION
Zeroed out all five flyTo/easeTo offset values in StoryMapView and the STORY_OFFSET constant in LiveMapEditor (was [-200, 0], now [0, 0]).

Hypothesis: with pitch applied, the horizontal offset produces an apparent vertical shift in screen space — causing the saved view to differ from playback. Removing the offset lets us confirm whether it is the sole root cause before deciding on a permanent solution.

Comments mark each change for easy revert: "was [-200, 0]"