### PR TITLE
Fix: include camera_center in slide field mapping on load

### DIFF
--- a/src/pages/StoryMapView.jsx
+++ b/src/pages/StoryMapView.jsx
@@ -266,6 +266,7 @@ export default function StoryMapView() {
                         description: s.description,
                         location: s.location,
                         coordinates: s.coordinates,
+                        camera_center: s.camera_center,
                         zoom: s.zoom,
                         bearing: s.bearing,
                         pitch: s.pitch,


### PR DESCRIPTION
The loadStory slide mapping was an explicit whitelist — camera_center was not in it, so it was stripped on every page load even when correctly stored in the database. Added camera_center: s.camera_center to the map.

This is why editor preview (local state) worked but playback after refresh fell back to slide.coordinates (EXIF location).