### PR TITLE
Fix: mount Sonner Toaster so toast messages actually render

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import './App.css'
 import { Toaster } from "@/components/ui/toaster"
+import { Toaster as SonnerToaster } from 'sonner'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { queryClientInstance } from '@/lib/query-client'
 import VisualEditAgent from '@/lib/VisualEditAgent'
@@ -85,6 +86,11 @@ function App() {
           <AuthenticatedApp />
         </Router>
         <Toaster />
+        <SonnerToaster
+          position="bottom-center"
+          toastOptions={{ style: { fontSize: '15px', padding: '14px 18px' } }}
+          richColors
+        />
         <VisualEditAgent />
       </QueryClientProvider>
     </AuthProvider>


### PR DESCRIPTION
Sonner's toast() calls had no Toaster component in the tree — they were falling back to a minimal built-in renderer that's barely visible. Added SonnerToaster to App.jsx with 15px font, generous padding, richColors, and bottom-center position.