### PR TITLE
Fix Live Map Editor persistence: send full slide object to base44

### DIFF
--- a/src/components/storymap/LiveMapEditor.jsx
+++ b/src/components/storymap/LiveMapEditor.jsx
@@ -172,11 +172,13 @@ export default function LiveMapEditor({ isOpen, onClose, activeSlide, mapInstanc
         if (!activeSlide?.id) { toast.error('No slide selected'); return; }
         setIsSaving(true);
         try {
-            const updateData = { zoom, bearing, pitch, fly_duration: flyDuration };
-            if (coordinatesModified && coordinates) updateData.coordinates = coordinates;
-            await base44.entities.Slide.update(activeSlide.id, updateData);
-            if (onSlideSave) onSlideSave(activeSlide.id, updateData);
-            toast.success('Slide saved');
+            const patchData = { zoom, bearing, pitch, fly_duration: flyDuration };
+            if (coordinatesModified && coordinates) patchData.coordinates = coordinates;
+            // Send the full slide object so base44 doesn't silently discard partial-update fields
+            const fullUpdateData = { ...activeSlide, ...patchData };
+            await base44.entities.Slide.update(activeSlide.id, fullUpdateData);
+            if (onSlideSave) onSlideSave(activeSlide.id, patchData);
+            toast.success(`Saved — zoom ${zoom.toFixed(1)}, bearing ${bearing}°, pitch ${pitch}°`);
         } catch {
             toast.error('Failed to save slide');
         } finally {

--- a/src/pages/StoryMapView.jsx
+++ b/src/pages/StoryMapView.jsx
@@ -781,6 +781,7 @@ export default function StoryMapView() {
                             slide.id === slideId ? { ...slide, ...values } : slide
                         )
                     })));
+                    setActiveSlide(prev => prev?.id === slideId ? { ...prev, ...values } : prev);
                 }}
             />
 


### PR DESCRIPTION
- LiveMapEditor.handleSave: merge patchData into activeSlide before calling Slide.update so base44 receives the full object (partial-only updates were silently discarded, same issue as camera_center)
- StoryMapView.onSlideSave: also update activeSlide state so the editor stays in sync when reopened on the same slide without navigating away
- Success toast now shows saved zoom/bearing/pitch for immediate feedback