### PR TITLE
Reinstate offset [-200,0] and restrict Capture View to camera params …

### DIFF
--- a/src/components/storymap/LiveMapEditor.jsx
+++ b/src/components/storymap/LiveMapEditor.jsx
@@ -129,15 +129,9 @@ export default function LiveMapEditor({ isOpen, onClose, activeSlide, mapInstanc
             const z = Math.round(map.getZoom() * 10) / 10;
             const b = Math.round(map.getBearing());
             const p = Math.round(map.getPitch());
-            const mc = map.getCenter();
-            const newCoords = [mc.lat, mc.lng];
             setZoom(z);
             setBearing(b);
             setPitch(p);
-            setCoordinates(newCoords);
-            setCoordinatesModified(true);
-            // Move amber dot to show the new flyTo centre
-            try { updateMarker(map, newCoords); } catch (_) {}
             toast.success(`Captured — zoom ${z}, bearing ${b}°, pitch ${p}°`);
         } catch (err) {
             toast.error('Capture failed: ' + (err?.message || 'unknown error'));
@@ -242,7 +236,7 @@ export default function LiveMapEditor({ isOpen, onClose, activeSlide, mapInstanc
                             <p className="text-[10px] text-slate-400 text-center mt-0.5">
                                 {justCaptured
                                     ? `zoom ${zoom.toFixed(1)}  bearing ${bearing}°  pitch ${pitch}°`
-                                    : 'Captures zoom, bearing, pitch & map centre (dot moves)'}
+                                    : 'Captures zoom, bearing & pitch — use Pin Location to move the target'}
                             </p>
                         </div>
 

--- a/src/pages/StoryMapView.jsx
+++ b/src/pages/StoryMapView.jsx
@@ -344,7 +344,7 @@ export default function StoryMapView() {
                                 !isNaN(firstSlide.coordinates[0]) && !isNaN(firstSlide.coordinates[1])) {
                                 setMapConfig({
                                     center: firstSlide.coordinates,
-                                    offset: [0, 0],
+                                    offset: [-200, 0],
                                     zoom: firstSlide?.zoom || 12,
                                     bearing: firstSlide?.bearing || 0,
                                     pitch: firstSlide?.pitch || 0,
@@ -527,7 +527,7 @@ export default function StoryMapView() {
                                     suppressNextOnSlideChangeMapConfig.current = true;
                                     setMapConfig({
                                         center: firstSlide.coordinates,
-                                        offset: [0, 0],
+                                        offset: [-200, 0],
                                         zoom: firstSlide.zoom || 12,
                                         bearing: firstSlide.bearing || 0,
                                         pitch: firstSlide.pitch || 0,
@@ -569,7 +569,7 @@ export default function StoryMapView() {
                                         suppressNextOnSlideChangeMapConfig.current = true;
                                         setMapConfig({
                                             center: firstSlide.coordinates,
-                                            offset: [0, 0],
+                                            offset: [-200, 0],
                                             zoom: firstSlide.zoom || 12,
                                             bearing: firstSlide.bearing || 0,
                                             pitch: firstSlide.pitch || 0,
@@ -678,7 +678,7 @@ export default function StoryMapView() {
                                 } else {
                                     setMapConfig({
                                         center: slide.coordinates,
-                                        offset: [0, 0],
+                                        offset: [-200, 0],
                                         zoom: slide.zoom !== undefined ? slide.zoom : (chapter.zoom || 12),
                                         bearing: slide.bearing !== undefined ? slide.bearing : 0,
                                         pitch: slide.pitch !== undefined ? slide.pitch : 0,


### PR DESCRIPTION
…only

- Restore offset: [-200, 0] at all four slide flyTo call sites in StoryMapView (handleScroll, onExplore, onContinue, onSlideChange). This returns the EXIF marker to its intended position beside the story card without the user needing to pan.

- Remove coordinate capture from captureMapPosition in LiveMapEditor. With the offset active, map.getCenter() is 200px left of the EXIF point; capturing it as coordinates caused marker drift. Capture View now captures zoom/bearing/pitch only. Coordinates change exclusively via Pin Location.

- Update Capture View hint text to reflect the narrower scope.