### PR TITLE
Various UI fixes: editor toggle, text panel exit, button position

### DIFF
--- a/src/components/storymap/FullScreenImageViewer.jsx
+++ b/src/components/storymap/FullScreenImageViewer.jsx
@@ -109,7 +109,7 @@ export default function FullScreenImageViewer({
                         className="fixed inset-0 z-[9998] bg-white overflow-y-auto pointer-events-auto"
                     >
                         {/* Consolidated controls: back · close · next */}
-                        <div className="absolute bottom-[80px] left-1/2 -translate-x-1/2 z-50 w-[240px] flex items-center justify-between">
+                        <div className="absolute bottom-[80px] left-[225px] -translate-x-1/2 z-50 w-[240px] flex items-center justify-between">
                             <button
                                 onClick={handlePrevious}
                                 disabled={!hasMultipleSlides}

--- a/src/components/storymap/LiveMapEditor.jsx
+++ b/src/components/storymap/LiveMapEditor.jsx
@@ -191,7 +191,7 @@ export default function LiveMapEditor({ isOpen, onClose, activeSlide, mapInstanc
                     initial={{ opacity: 0, x: -20, y: '-50%' }}
                     animate={{ opacity: 1, x: 0, y: '-50%' }}
                     exit={{ opacity: 0, x: -20, y: '-50%' }}
-                    transition={{ type: 'spring', damping: 20, stiffness: 200 }}
+                    transition={{ type: 'tween', duration: 1, ease: [0.25, 0.46, 0.45, 0.94] }}
                     className="fixed top-1/2 left-[40px] z-[9990] w-[300px] bg-white/97 backdrop-blur-xl rounded-xl shadow-2xl border border-slate-200/60"
                 >
                     {/* Header */}

--- a/src/components/storymap/TextPanelCarousel.jsx
+++ b/src/components/storymap/TextPanelCarousel.jsx
@@ -99,8 +99,8 @@ const TextPanelCarousel = ({ chapterTitle, slideTitle, description, extendedCont
       opacity: 0,
       y: 100,
       transition: {
-        duration: 0.8,
-        delay: 2.2
+        duration: 0.4,
+        delay: 0.2
       }
     }
   };
@@ -115,7 +115,7 @@ const TextPanelCarousel = ({ chapterTitle, slideTitle, description, extendedCont
     exit: {
       opacity: 0,
       y: -10,
-      transition: { duration: 0.4, delay: 1.8 }
+      transition: { duration: 0.3, delay: 0.15 }
     }
   };
 
@@ -129,7 +129,7 @@ const TextPanelCarousel = ({ chapterTitle, slideTitle, description, extendedCont
     exit: {
       opacity: 0,
       y: -10,
-      transition: { duration: 0.4, delay: 1.2 }
+      transition: { duration: 0.3, delay: 0.1 }
     }
   };
 
@@ -143,7 +143,7 @@ const TextPanelCarousel = ({ chapterTitle, slideTitle, description, extendedCont
     exit: {
       opacity: 0,
       y: -10,
-      transition: { duration: 0.4, delay: 0.6 }
+      transition: { duration: 0.3, delay: 0.05 }
     }
   };
 
@@ -157,7 +157,7 @@ const TextPanelCarousel = ({ chapterTitle, slideTitle, description, extendedCont
     exit: {
       opacity: 0,
       y: -10,
-      transition: { duration: 0.4 }
+      transition: { duration: 0.3 }
     }
   };
 
@@ -321,7 +321,7 @@ const TextPanelCarousel = ({ chapterTitle, slideTitle, description, extendedCont
 
             {/* Slide Counter */}
             {slideCounter && (
-              <div className="text-sm text-gray-500 text-right mt-2">{slideCounter}</div>
+              <div className="text-sm text-gray-500 text-right mt-2 mb-5">{slideCounter}</div>
             )}
 
             {/* Page indicators */}

--- a/src/pages/StoryMapView.jsx
+++ b/src/pages/StoryMapView.jsx
@@ -730,7 +730,7 @@ export default function StoryMapView() {
                     onOpenLibrary={() => setShowLibraryModal(true)}
                     relatedStories={relatedStories}
                     currentCategory={story?.category}
-                    onOpenMapEditor={() => setIsLiveEditorOpen(true)}
+                    onOpenMapEditor={() => setIsLiveEditorOpen(prev => !prev)}
                     isOwner={true}
                 />
                 </div>


### PR DESCRIPTION
LiveMapEditor:
- Slide-in animation changed from fast spring to 1s ease-out tween
- Footer icon now toggles editor open/closed (was open-only)

TextPanelCarousel:
- Slide counter gets mb-5 (20px bottom margin) to prevent overlap with the Prev/Exit/Next buttons
- Exit delays removed (were up to 2.2s); elements now exit immediately with a tiny cascading stagger (0–0.2s) — entrance timing unchanged

FullScreenImageViewer:
- Prev/Exit/Next button group repositioned from left-1/2 (screen centre) to left-[225px] (centre of the 400px text panel at left-[25px])