### PR TITLE
Consolidate slide nav into TextPanelCarousel; location always visible

### DIFF
--- a/src/components/storymap/FullScreenImageViewer.jsx
+++ b/src/components/storymap/FullScreenImageViewer.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { X, ChevronLeft, ChevronRight } from 'lucide-react';
 import TextPanelCarousel from './TextPanelCarousel';
 
 const VideoPlayer = ({ url }) => {
@@ -108,30 +107,6 @@ export default function FullScreenImageViewer({
                         transition={{ duration: 1.5, ease: "easeOut" }}
                         className="fixed inset-0 z-[9998] bg-white overflow-y-auto pointer-events-auto"
                     >
-                        {/* Consolidated controls: back · close · next */}
-                        <div className="absolute bottom-[80px] left-[225px] -translate-x-1/2 z-50 w-[400px] bg-white/60 backdrop-blur-md rounded-lg shadow-lg flex items-center justify-between py-[15px] px-8">
-                            <button
-                                onClick={handlePrevious}
-                                disabled={!hasMultipleSlides}
-                                className="bg-black/10 hover:bg-black/20 rounded-full p-3 transition-all disabled:opacity-30 disabled:cursor-not-allowed"
-                            >
-                                <ChevronLeft className="w-6 h-6 text-slate-700" />
-                            </button>
-                            <button
-                                onClick={onClose}
-                                className="bg-black/10 hover:bg-black/20 rounded-full p-3 transition-all"
-                            >
-                                <X className="w-6 h-6 text-slate-700" />
-                            </button>
-                            <button
-                                onClick={handleNext}
-                                disabled={!hasMultipleSlides}
-                                className="bg-black/10 hover:bg-black/20 rounded-full p-3 transition-all disabled:opacity-30 disabled:cursor-not-allowed"
-                            >
-                                <ChevronRight className="w-6 h-6 text-slate-700" />
-                            </button>
-                        </div>
-
                         {/* Image or Video Display */}
                         <div className="relative w-full h-full flex items-center justify-center z-10">
                     <AnimatePresence mode="wait">
@@ -163,6 +138,10 @@ export default function FullScreenImageViewer({
                                     extendedContent={currentSlide.extended_content || ''}
                                     location={currentSlide.location}
                                     slideCounter={hasMultipleSlides ? `${currentIndex + 1} / ${slides.length}` : null}
+                                    onPrevSlide={handlePrevious}
+                                    onNextSlide={handleNext}
+                                    onClose={onClose}
+                                    hasMultipleSlides={hasMultipleSlides}
                                 />
                             </AnimatePresence>
                         </div>

--- a/src/components/storymap/TextPanelCarousel.jsx
+++ b/src/components/storymap/TextPanelCarousel.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
+import { ChevronLeft, ChevronRight, X } from 'lucide-react';
 
 /**
  * TextPanelCarousel Component
@@ -11,10 +12,18 @@ import { motion, AnimatePresence } from 'framer-motion';
  * @param {string} slideTitle - Large bold heading (e.g., "Nairobi After Dark")
  * @param {string} description - First page content as HTML string (always short, never split)
  * @param {string|string[]} extendedContent - HTML string or array of HTML strings (auto-splits at 550 chars)
- * @param {string} location - Location text with orange circle indicator
+ * @param {string} location - Location text with orange circle indicator (always visible, even when collapsed)
  * @param {string|null} slideCounter - Slide counter text (e.g., "2 / 5") or null
+ * @param {function} onPrevSlide - Navigate to previous slide in fullscreen
+ * @param {function} onNextSlide - Navigate to next slide in fullscreen
+ * @param {function} onClose - Close fullscreen viewer
+ * @param {boolean} hasMultipleSlides - Whether prev/next slide buttons should be enabled
  */
-const TextPanelCarousel = ({ chapterTitle, slideTitle, description, extendedContent, location, slideCounter }) => {
+const TextPanelCarousel = ({
+  chapterTitle, slideTitle, description, extendedContent,
+  location, slideCounter,
+  onPrevSlide, onNextSlide, onClose, hasMultipleSlides
+}) => {
   const [currentPage, setCurrentPage] = useState(0);
   const [previousPage, setPreviousPage] = useState(0);
   const [direction, setDirection] = useState(0);
@@ -55,8 +64,6 @@ const TextPanelCarousel = ({ chapterTitle, slideTitle, description, extendedCont
     return pages.length > 0 ? pages : [html];
   };
 
-  // Description is always first page (always short, no splitting needed)
-  // Split each extendedContent item if it exceeds 550 characters
   const splitExtendedContent = extendedArray.flatMap(content =>
     splitHtmlIntoPages(content)
   );
@@ -84,82 +91,40 @@ const TextPanelCarousel = ({ chapterTitle, slideTitle, description, extendedCont
     }, 100);
   }, []);
 
-  // Animation variants
+  // ── Animation variants ──────────────────────────────────────────────────────
+
   const panelVariants = {
     hidden: { opacity: 0, y: -100 },
-    visible: {
-      opacity: 1,
-      y: 0,
-      transition: {
-        duration: 1,
-        delay: 1
-      }
-    },
-    exit: {
-      opacity: 0,
-      y: 100,
-      transition: {
-        duration: 0.4,
-        delay: 0.2
-      }
-    }
+    visible: { opacity: 1, y: 0, transition: { duration: 1, delay: 1 } },
+    exit:    { opacity: 0, y: 100, transition: { duration: 0.4, delay: 0.2 } }
   };
 
   const chapterVariants = {
-    hidden: { opacity: 0, y: 10 },
-    visible: {
-      opacity: 1,
-      y: 0,
-      transition: { duration: 0.6, delay: 2.2 }
-    },
-    exit: {
-      opacity: 0,
-      y: -10,
-      transition: { duration: 0.3, delay: 0.15 }
-    }
+    hidden:  { opacity: 0, y: 10 },
+    visible: { opacity: 1, y: 0, transition: { duration: 0.6, delay: 2.2 } },
+    exit:    { opacity: 0, y: -10, transition: { duration: 0.3, delay: 0.15 } }
+  };
+
+  // Location now sits between chapter header and collapsible; delay between 2.2 and 2.8
+  const locationVariants = {
+    hidden:  { opacity: 0, y: 10 },
+    visible: { opacity: 1, y: 0, transition: { duration: 0.6, delay: 2.5 } },
+    exit:    { opacity: 0, y: -10, transition: { duration: 0.3, delay: 0.05 } }
   };
 
   const slideVariants = {
-    hidden: { opacity: 0, y: 10 },
-    visible: {
-      opacity: 1,
-      y: 0,
-      transition: { duration: 0.6, delay: 2.8 }
-    },
-    exit: {
-      opacity: 0,
-      y: -10,
-      transition: { duration: 0.3, delay: 0.1 }
-    }
-  };
-
-  const locationVariants = {
-    hidden: { opacity: 0, y: 10 },
-    visible: {
-      opacity: 1,
-      y: 0,
-      transition: { duration: 0.6, delay: 3.4 }
-    },
-    exit: {
-      opacity: 0,
-      y: -10,
-      transition: { duration: 0.3, delay: 0.05 }
-    }
+    hidden:  { opacity: 0, y: 10 },
+    visible: { opacity: 1, y: 0, transition: { duration: 0.6, delay: 2.8 } },
+    exit:    { opacity: 0, y: -10, transition: { duration: 0.3, delay: 0.1 } }
   };
 
   const contentVariants = {
-    hidden: { opacity: 0, y: 10 },
-    visible: {
-      opacity: 1,
-      y: 0,
-      transition: { duration: 0.6, delay: 4.0 }
-    },
-    exit: {
-      opacity: 0,
-      y: -10,
-      transition: { duration: 0.3 }
-    }
+    hidden:  { opacity: 0, y: 10 },
+    visible: { opacity: 1, y: 0, transition: { duration: 0.6, delay: 4.0 } },
+    exit:    { opacity: 0, y: -10, transition: { duration: 0.3 } }
   };
+
+  // ── Page navigation ─────────────────────────────────────────────────────────
 
   const nextPage = () => {
     if (currentPage < pages.length - 1) {
@@ -191,7 +156,7 @@ const TextPanelCarousel = ({ chapterTitle, slideTitle, description, extendedCont
       animate="visible"
       exit="exit"
     >
-      {/* Chapter Title with Toggle - Always visible */}
+      {/* Chapter Title with Toggle — always visible */}
       {chapterTitle && (
         <motion.div
           className="mb-2 flex items-center justify-between"
@@ -202,7 +167,7 @@ const TextPanelCarousel = ({ chapterTitle, slideTitle, description, extendedCont
             exit: "exit"
           })}
         >
-          <h2 className="text-sm font-semibold text-gray-600 uppercase tracking-wide text-right flex-1 pb-[15px]">
+          <h2 className="text-sm font-semibold text-gray-600 uppercase tracking-wide text-right flex-1">
             {chapterTitle}
           </h2>
           <button
@@ -214,16 +179,31 @@ const TextPanelCarousel = ({ chapterTitle, slideTitle, description, extendedCont
             <svg
               className="w-5 h-5 text-black transition-transform duration-300"
               style={{ transform: isOpen ? 'rotate(0deg)' : 'rotate(180deg)' }}
-              fill="none"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
+              fill="none" strokeLinecap="round" strokeLinejoin="round"
+              strokeWidth="2" viewBox="0 0 24 24" stroke="currentColor"
             >
-              <path d="M19 9l-7 7-7-7"></path>
+              <path d="M19 9l-7 7-7-7" />
             </svg>
           </button>
+        </motion.div>
+      )}
+
+      {/* Location — always visible, persists when panel is collapsed */}
+      {location && (
+        <motion.div
+          className="flex items-center justify-end gap-2 mb-4"
+          {...(!hasAnimatedIn && {
+            variants: locationVariants,
+            initial: "hidden",
+            animate: "visible",
+            exit: "exit"
+          })}
+        >
+          <span className="text-sm text-gray-600 text-right min-w-0">{location}</span>
+          <div
+            className="flex-shrink-0 w-10 h-10 rounded-full"
+            style={{ background: '#d97706', border: '3px solid white', boxShadow: '0 2px 8px rgba(0,0,0,0.3)' }}
+          />
         </motion.div>
       )}
 
@@ -259,10 +239,8 @@ const TextPanelCarousel = ({ chapterTitle, slideTitle, description, extendedCont
             <motion.div
               className="relative overflow-hidden"
               animate={{ height: contentHeight }}
-              transition={{
-                height: { duration: 1, ease: "easeInOut" }
-              }}
-              onAnimationComplete={(definition) => {
+              transition={{ height: { duration: 1, ease: "easeInOut" } }}
+              onAnimationComplete={() => {
                 if (!hasAnimatedIn) {
                   setTimeout(() => setHasAnimatedIn(true), 4600);
                 }
@@ -296,108 +274,82 @@ const TextPanelCarousel = ({ chapterTitle, slideTitle, description, extendedCont
               </motion.div>
             </motion.div>
 
-            {/* Location */}
-            {location && (
-              <motion.div
-                className="flex items-center justify-end gap-2 mt-6 mb-[30px]"
-                {...(!hasAnimatedIn && {
-                  variants: locationVariants,
-                  initial: "hidden",
-                  animate: "visible",
-                  exit: "exit"
-                })}
-              >
-                <span className="text-sm text-gray-600 text-right min-w-0">{location}</span>
-                <div
-                  className="flex-shrink-0 w-10 h-10 rounded-full"
-                  style={{
-                    background: '#d97706',
-                    border: '3px solid white',
-                    boxShadow: '0 2px 8px rgba(0,0,0,0.3)'
-                  }}
-                />
-              </motion.div>
-            )}
-
             {/* Slide Counter */}
             {slideCounter && (
-              <div className="text-sm text-gray-500 text-right mt-2 mb-5">{slideCounter}</div>
+              <div className="text-sm text-gray-500 text-right mt-4 mb-2">{slideCounter}</div>
             )}
 
-            {/* Page indicators */}
+            {/* Page indicators + inline prev/next page arrows */}
             {pages.length > 1 && (
-              <div className={`flex items-center justify-center gap-2 ${!location ? 'mt-[30px]' : ''}`}>
+              <div className="flex items-center justify-center gap-2 mt-4">
+                <button
+                  onClick={prevPage}
+                  disabled={currentPage === 0}
+                  className="w-7 h-7 rounded-full bg-black/10 hover:bg-black/20
+                             disabled:opacity-30 disabled:cursor-not-allowed
+                             flex items-center justify-center transition-all"
+                  aria-label="Previous page"
+                >
+                  <ChevronLeft className="w-4 h-4 text-black" />
+                </button>
+
                 {pages.map((_, index) => (
                   <button
                     key={index}
                     onClick={() => goToPage(index)}
                     className={`h-1 rounded-full transition-all duration-300 cursor-pointer ${
-                      index === currentPage
-                        ? 'w-8 bg-black'
-                        : 'w-8 bg-black/30 hover:bg-black/50'
+                      index === currentPage ? 'w-8 bg-black' : 'w-8 bg-black/30 hover:bg-black/50'
                     }`}
                     aria-label={`Go to page ${index + 1}`}
                   />
                 ))}
-                <span className="ml-2 text-sm text-black/60">
+
+                <span className="text-sm text-black/60">
                   {currentPage + 1} / {pages.length}
                 </span>
-              </div>
-            )}
 
-            {/* Navigation arrows - visible on hover */}
-            {pages.length > 1 && (
-              <>
-                <button
-                  onClick={prevPage}
-                  disabled={currentPage === 0}
-                  className="absolute left-2 bottom-6
-                             w-10 h-10 rounded-full bg-black/10 hover:bg-black/20
-                             disabled:opacity-30 disabled:cursor-not-allowed
-                             flex items-center justify-center
-                             opacity-0 group-hover:opacity-100
-                             transition-opacity duration-300
-                             backdrop-blur-sm"
-                  aria-label="Previous page"
-                >
-                  <svg
-                    className="w-6 h-6 text-black"
-                    fill="none"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path d="M15 19l-7-7 7-7"></path>
-                  </svg>
-                </button>
                 <button
                   onClick={nextPage}
                   disabled={currentPage === pages.length - 1}
-                  className="absolute right-2 bottom-6
-                             w-10 h-10 rounded-full bg-black/10 hover:bg-black/20
+                  className="w-7 h-7 rounded-full bg-black/10 hover:bg-black/20
                              disabled:opacity-30 disabled:cursor-not-allowed
-                             flex items-center justify-center
-                             opacity-0 group-hover:opacity-100
-                             transition-opacity duration-300
-                             backdrop-blur-sm"
+                             flex items-center justify-center transition-all"
                   aria-label="Next page"
                 >
-                  <svg
-                    className="w-6 h-6 text-black"
-                    fill="none"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path d="M9 5l7 7-7 7"></path>
-                  </svg>
+                  <ChevronRight className="w-4 h-4 text-black" />
                 </button>
-              </>
+              </div>
             )}
+
+            {/* Slide navigation — generous gap above to separate from page nav */}
+            <div className="mt-10 flex items-center justify-between">
+              <button
+                onClick={onPrevSlide}
+                disabled={!hasMultipleSlides}
+                className="bg-black/10 hover:bg-black/20 rounded-full p-3 transition-all
+                           disabled:opacity-30 disabled:cursor-not-allowed"
+                aria-label="Previous slide"
+              >
+                <ChevronLeft className="w-6 h-6 text-slate-700" />
+              </button>
+              <button
+                onClick={onClose}
+                className="bg-black/10 hover:bg-black/20 rounded-full p-3 transition-all"
+                aria-label="Close"
+              >
+                <X className="w-6 h-6 text-slate-700" />
+              </button>
+              <button
+                onClick={onNextSlide}
+                disabled={!hasMultipleSlides}
+                className="bg-black/10 hover:bg-black/20 rounded-full p-3 transition-all
+                           disabled:opacity-30 disabled:cursor-not-allowed"
+                aria-label="Next slide"
+              >
+                <ChevronRight className="w-6 h-6 text-slate-700" />
+              </button>
+            </div>
+
           </motion.div>
         )}
       </AnimatePresence>


### PR DESCRIPTION
TextPanelCarousel:
- Add onPrevSlide, onNextSlide, onClose, hasMultipleSlides props
- Location + orange circle moved above collapsible block so it remains visible when the panel is collapsed (alongside chapter name)
- Location entrance delay adjusted to 2.5s (between chapter 2.2s and slide title 2.8s) to maintain logical stagger
- Slide nav buttons (‹ × ›) placed at bottom of collapsible with mt-10 generous gap above separating them from page navigation
- Absolute-positioned hover arrows replaced with inline page nav (‹ · dots · count · ›) in one row — removes overlap with slide nav

FullScreenImageViewer:
- Pass four new props to TextPanelCarousel
- Remove standalone button group div (now redundant)
- Remove unused lucide-react imports